### PR TITLE
Fix H6: ATA missing 400 ns settle and post-write completion/flush

### DIFF
--- a/main64/kernel/src/drivers/ata.rs
+++ b/main64/kernel/src/drivers/ata.rs
@@ -80,6 +80,16 @@ impl StatusRegister {
 /// Maximum number of polling iterations before ATA waits time out.
 const ATA_POLL_TIMEOUT_ITERATIONS: u32 = 10_000;
 
+/// Maximum number of polling iterations before a CACHE FLUSH completion wait
+/// times out.
+///
+/// A drive can legitimately take much longer to persist a full write cache
+/// to stable media than to complete a single sector's DRQ handshake, so
+/// FLUSH CACHE gets a more generous budget than [`ATA_POLL_TIMEOUT_ITERATIONS`]
+/// instead of sharing the tight per-sector one, which would risk a spurious
+/// `AtaError::Timeout` on real hardware with a large dirty write cache.
+const ATA_CACHE_FLUSH_TIMEOUT_ITERATIONS: u32 = 100_000;
+
 /// Errors that can occur during ATA operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AtaError {
@@ -207,7 +217,15 @@ impl AtaPio {
     /// registers is not required for FLUSH CACHE - the preceding
     /// `setup_command` call already selected the target drive, and only the
     /// command byte needs to be written here.
-    fn issue_cache_flush(&self) {
+    ///
+    /// Waits for BSY to clear before writing the command byte, mirroring
+    /// `setup_command`'s own precondition check, rather than relying on the
+    /// caller to have already ensured the device is idle. This keeps the
+    /// method self-contained and safe to call correctly on its own, even
+    /// though today's only call site already waits beforehand.
+    fn issue_cache_flush(&self) -> Result<(), AtaError> {
+        self.wait_bsy_clear()?;
+
         // SAFETY:
         // - This requires `unsafe` because it performs operations that Rust marks as potentially violating memory or concurrency invariants.
         // - Writes the ATA command register on the configured bus.
@@ -218,6 +236,8 @@ impl AtaPio {
 
         // Same settle rationale as after any other command-register write.
         self.settle_after_command();
+
+        Ok(())
     }
 }
 
@@ -309,18 +329,6 @@ fn with_controller<R>(f: impl FnOnce(&AtaPio) -> R) -> R {
     f(&ata)
 }
 
-fn status_is_ready(status: StatusRegister) -> Result<bool, AtaError> {
-    // Error bits have priority over readiness; callers must fail fast.
-    if status.has_error() {
-        return Err(AtaError::DeviceError);
-    }
-    if status.has_fault() {
-        return Err(AtaError::DeviceFault);
-    }
-
-    Ok(!status.is_busy() && status.is_drq())
-}
-
 fn can_sleep_on_irq() -> Option<usize> {
     // Sleeping on IRQ wait queues requires a live scheduler and enabled IRQs.
     if !scheduler::is_running() || !interrupts::are_enabled() {
@@ -331,23 +339,39 @@ fn can_sleep_on_irq() -> Option<usize> {
     scheduler::current_task_id()
 }
 
-/// Wait until controller reports `!BSY && DRQ`.
+/// Shared polling core for every "wait for a controller status condition"
+/// loop in this driver.
 ///
-/// Primary mode is cooperative IRQ-hinted polling:
+/// Samples the status register under the controller lock, fails fast on
+/// ERR/DF (checked before `condition`, since error bits take priority over
+/// whatever positive condition the caller is waiting for), and otherwise
+/// calls `condition` to decide whether the awaited state has been reached.
+/// Bounded by `timeout_iterations` polling rounds; between rounds, uses
+/// cooperative IRQ-hinted polling:
 /// - IRQ14 sets `IRQ_EVENT_PENDING` as a wake hint.
 /// - The requester re-checks status in a loop and yields between checks.
 ///
 /// This avoids deadlocks on hardware/controllers that do not reliably deliver
 /// ATA IRQ edges for every intermediate device state transition.
-fn wait_ready_or_error() -> Result<(), AtaError> {
-    let mut timeout = ATA_POLL_TIMEOUT_ITERATIONS;
+fn poll_status_until(
+    timeout_iterations: u32,
+    condition: impl Fn(StatusRegister) -> bool,
+) -> Result<(), AtaError> {
+    let mut timeout = timeout_iterations;
 
     loop {
         // Step 1: sample controller status under controller lock.
         let status = with_controller(AtaPio::read_status);
 
-        // Step 2: terminate on ERR/DF or succeed on !BSY && DRQ.
-        if status_is_ready(status)? {
+        // Step 2: error bits have priority over the awaited condition;
+        // callers must fail fast.
+        if status.has_error() {
+            return Err(AtaError::DeviceError);
+        }
+        if status.has_fault() {
+            return Err(AtaError::DeviceFault);
+        }
+        if condition(status) {
             return Ok(());
         }
 
@@ -375,55 +399,25 @@ fn wait_ready_or_error() -> Result<(), AtaError> {
     }
 }
 
+/// Wait until controller reports `!BSY && DRQ`, i.e. the per-sector
+/// read/write data-request handshake.
+fn wait_ready_or_error() -> Result<(), AtaError> {
+    poll_status_until(ATA_POLL_TIMEOUT_ITERATIONS, |status| {
+        !status.is_busy() && status.is_drq()
+    })
+}
+
 /// Wait for command completion (BSY clear) without requiring DRQ.
 ///
 /// Unlike [`wait_ready_or_error`], which is used for the read/write
 /// per-sector data-request handshake, this is used after the *last* sector
 /// of a write and after CACHE FLUSH, where DRQ is not expected to be set
-/// again. Uses the same cooperative IRQ-hinted polling strategy so a
-/// comparatively slow CACHE FLUSH (real drives can take much longer to
-/// flush a write cache than to transfer a single sector) does not
-/// needlessly spin-block other tasks.
-fn wait_completion_or_error() -> Result<(), AtaError> {
-    let mut timeout = ATA_POLL_TIMEOUT_ITERATIONS;
-
-    loop {
-        // Step 1: sample controller status under controller lock.
-        let status = with_controller(AtaPio::read_status);
-
-        // Step 2: terminate on ERR/DF or succeed on !BSY.
-        if !status.is_busy() {
-            if status.has_error() {
-                return Err(AtaError::DeviceError);
-            }
-            if status.has_fault() {
-                return Err(AtaError::DeviceFault);
-            }
-            return Ok(());
-        }
-
-        // Step 3: abort after bounded retries to prevent unbounded kernel hangs.
-        if timeout == 0 {
-            return Err(AtaError::Timeout);
-        }
-
-        timeout -= 1;
-
-        if can_sleep_on_irq().is_some() {
-            // Step 4a: consume a pending IRQ edge before yielding.
-            // If one is already queued, re-check status immediately.
-            if IRQ_EVENT_PENDING.swap(false, Ordering::AcqRel) {
-                continue;
-            }
-
-            // Step 4b: no pending IRQ hint; yield once and poll again.
-            // This keeps the system responsive even if an IRQ edge is missed.
-            scheduler::yield_now();
-        } else {
-            // Step 4c: fallback for contexts without scheduler/IRQs.
-            core::hint::spin_loop();
-        }
-    }
+/// again. `timeout_iterations` is caller-supplied so a comparatively slow
+/// CACHE FLUSH (real drives can take much longer to flush a write cache
+/// than to transfer a single sector) can be given a more generous budget
+/// than the tight per-sector wait, instead of risking a spurious timeout.
+fn wait_completion_or_error(timeout_iterations: u32) -> Result<(), AtaError> {
+    poll_status_until(timeout_iterations, |status| !status.is_busy())
 }
 
 /// IRQ14 top-half handler for the primary ATA controller.
@@ -615,12 +609,15 @@ pub fn write_sectors(buffer: &[u8], lba: u32, sector_count: u8) -> Result<(), At
     // Step 4: wait for the final sector's completion (BSY clear) and bail
     // out on a device-reported error/fault before trusting the write, or
     // before touching the write cache with a FLUSH command.
-    wait_completion_or_error()?;
+    wait_completion_or_error(ATA_POLL_TIMEOUT_ITERATIONS)?;
 
     // Step 5: flush the drive's write cache so the data just written is
     // durable on stable media, then wait for the flush itself to complete.
-    with_controller(|ata| ata.issue_cache_flush());
-    wait_completion_or_error()?;
+    // The flush completion wait gets a larger, dedicated timeout budget
+    // since persisting a full write cache can legitimately take much
+    // longer than an ordinary per-sector handshake.
+    with_controller(|ata| ata.issue_cache_flush())?;
+    wait_completion_or_error(ATA_CACHE_FLUSH_TIMEOUT_ITERATIONS)?;
 
     Ok(())
 }

--- a/main64/kernel/src/drivers/ata.rs
+++ b/main64/kernel/src/drivers/ata.rs
@@ -29,9 +29,23 @@ const LBA_HIGH_OFFSET: u16 = 5;
 const DRIVE_HEAD_OFFSET: u16 = 6;
 const STATUS_COMMAND_OFFSET: u16 = 7;
 
+/// Primary ATA controller *control block* base I/O port.
+///
+/// This is a genuinely separate I/O port range from the command block
+/// (`PRIMARY_BASE`, ports 0x1F0-0x1F7) per the ATA/ATAPI specification -
+/// it is not reachable as an offset from `PRIMARY_BASE`. The "alternate
+/// status" register lives here; unlike the regular status register at
+/// `PRIMARY_BASE + STATUS_COMMAND_OFFSET`, reading it has no side effect
+/// of acknowledging/clearing a pending IRQ, which makes it safe to poll
+/// purely for timing purposes.
+const PRIMARY_CONTROL_BASE: u16 = 0x3F6;
+
 /// ATA PIO commands.
 const ATA_CMD_READ_SECTORS: u8 = 0x20;
 const ATA_CMD_WRITE_SECTORS: u8 = 0x30;
+
+/// Flush the drive's write cache to stable media (28-bit command set).
+const ATA_CMD_CACHE_FLUSH: u8 = 0xE7;
 
 /// Drive select byte: master drive, LBA mode.
 const DRIVE_SELECT_MASTER_LBA: u8 = 0xE0;
@@ -91,6 +105,7 @@ pub struct AtaPio {
     lba_high: PortByte,
     drive_head: PortByte,
     status_cmd: PortByte,
+    alt_status: PortByte,
 }
 
 impl AtaPio {
@@ -104,6 +119,9 @@ impl AtaPio {
             lba_high: PortByte::new(base + LBA_HIGH_OFFSET),
             drive_head: PortByte::new(base + DRIVE_HEAD_OFFSET),
             status_cmd: PortByte::new(base + STATUS_COMMAND_OFFSET),
+            // The control block lives at a fixed, separate base address
+            // per the ATA spec, not at an offset within the command block.
+            alt_status: PortByte::new(PRIMARY_CONTROL_BASE),
         }
     }
 
@@ -114,6 +132,28 @@ impl AtaPio {
         // - Reading ATA status uses the controller I/O port for this device.
         // - `self.status_cmd` was constructed from the ATA base port.
         unsafe { StatusRegister(self.status_cmd.read()) }
+    }
+
+    /// Burn ~400 ns after issuing a command by reading the alternate status
+    /// register four times, discarding the value.
+    ///
+    /// This is the well-known, industry-wide "400 ns settle" convention:
+    /// the drive is allowed to take a few hundred nanoseconds after a
+    /// command-register write before it asserts BSY, so the very first
+    /// status sample taken right after the write can observe stale
+    /// `!BSY && DRQ` from the *previous* command. Reading the alternate
+    /// status register (rather than the regular status register) avoids
+    /// accidentally acknowledging/clearing a pending IRQ while doing so.
+    fn settle_after_command(&self) {
+        // SAFETY:
+        // - This requires `unsafe` because it performs operations that Rust marks as potentially violating memory or concurrency invariants.
+        // - Reading the alternate status port has no side effect (no IRQ ack) and is used here purely to burn time.
+        // - `self.alt_status` was constructed from the documented primary control-block base port.
+        for _ in 0..4 {
+            unsafe {
+                let _ = self.alt_status.read();
+            }
+        }
     }
 
     /// Busy-wait until the BSY flag is cleared.
@@ -152,7 +192,32 @@ impl AtaPio {
             self.status_cmd.write(command);
         }
 
+        // Give the drive time to assert BSY before the caller trusts the
+        // first real-status sample. Without this, a fast real CPU can read
+        // stale `!BSY && DRQ` left over from the previous command.
+        self.settle_after_command();
+
         Ok(())
+    }
+
+    /// Issue CACHE FLUSH (0xE7) to persist the drive's write cache to
+    /// stable media.
+    ///
+    /// Per the ATA spec, re-programming the LBA/sector-count/drive-head
+    /// registers is not required for FLUSH CACHE - the preceding
+    /// `setup_command` call already selected the target drive, and only the
+    /// command byte needs to be written here.
+    fn issue_cache_flush(&self) {
+        // SAFETY:
+        // - This requires `unsafe` because it performs operations that Rust marks as potentially violating memory or concurrency invariants.
+        // - Writes the ATA command register on the configured bus.
+        // - The drive/head register still selects the correct target drive from the preceding `setup_command` call.
+        unsafe {
+            self.status_cmd.write(ATA_CMD_CACHE_FLUSH);
+        }
+
+        // Same settle rationale as after any other command-register write.
+        self.settle_after_command();
     }
 }
 
@@ -283,6 +348,57 @@ fn wait_ready_or_error() -> Result<(), AtaError> {
 
         // Step 2: terminate on ERR/DF or succeed on !BSY && DRQ.
         if status_is_ready(status)? {
+            return Ok(());
+        }
+
+        // Step 3: abort after bounded retries to prevent unbounded kernel hangs.
+        if timeout == 0 {
+            return Err(AtaError::Timeout);
+        }
+
+        timeout -= 1;
+
+        if can_sleep_on_irq().is_some() {
+            // Step 4a: consume a pending IRQ edge before yielding.
+            // If one is already queued, re-check status immediately.
+            if IRQ_EVENT_PENDING.swap(false, Ordering::AcqRel) {
+                continue;
+            }
+
+            // Step 4b: no pending IRQ hint; yield once and poll again.
+            // This keeps the system responsive even if an IRQ edge is missed.
+            scheduler::yield_now();
+        } else {
+            // Step 4c: fallback for contexts without scheduler/IRQs.
+            core::hint::spin_loop();
+        }
+    }
+}
+
+/// Wait for command completion (BSY clear) without requiring DRQ.
+///
+/// Unlike [`wait_ready_or_error`], which is used for the read/write
+/// per-sector data-request handshake, this is used after the *last* sector
+/// of a write and after CACHE FLUSH, where DRQ is not expected to be set
+/// again. Uses the same cooperative IRQ-hinted polling strategy so a
+/// comparatively slow CACHE FLUSH (real drives can take much longer to
+/// flush a write cache than to transfer a single sector) does not
+/// needlessly spin-block other tasks.
+fn wait_completion_or_error() -> Result<(), AtaError> {
+    let mut timeout = ATA_POLL_TIMEOUT_ITERATIONS;
+
+    loop {
+        // Step 1: sample controller status under controller lock.
+        let status = with_controller(AtaPio::read_status);
+
+        // Step 2: terminate on ERR/DF or succeed on !BSY.
+        if !status.is_busy() {
+            if status.has_error() {
+                return Err(AtaError::DeviceError);
+            }
+            if status.has_fault() {
+                return Err(AtaError::DeviceFault);
+            }
             return Ok(());
         }
 
@@ -495,6 +611,16 @@ pub fn write_sectors(buffer: &[u8], lba: u32, sector_count: u8) -> Result<(), At
             }
         });
     }
+
+    // Step 4: wait for the final sector's completion (BSY clear) and bail
+    // out on a device-reported error/fault before trusting the write, or
+    // before touching the write cache with a FLUSH command.
+    wait_completion_or_error()?;
+
+    // Step 5: flush the drive's write cache so the data just written is
+    // durable on stable media, then wait for the flush itself to complete.
+    with_controller(|ata| ata.issue_cache_flush());
+    wait_completion_or_error()?;
 
     Ok(())
 }

--- a/main64/kernel/tests/ata_test.rs
+++ b/main64/kernel/tests/ata_test.rs
@@ -180,3 +180,139 @@ fn test_ata_write_read_roundtrip_returns_written_data() {
         "ATA roundtrip mismatch: read-back bytes differ from written payload"
     );
 }
+
+/// Contract: write_sectors performs its post-write completion wait and
+/// CACHE FLUSH without erroring or hanging, and the flushed data survives
+/// a subsequent read.
+///
+/// Given: ATA subsystem was initialized and a writable test sector is chosen.
+/// When: A multi-sector payload is written (exercising `wait_completion_or_error`
+///   and `issue_cache_flush` in `write_sectors` after the transfer loop) and then
+///   read back.
+/// Then: `write_sectors` must return `Ok`, and the read-back bytes must exactly
+///   match what was written, i.e. the flush path neither corrupts data nor
+///   returns before the drive has actually accepted the write.
+///
+/// Note: QEMU's virtual ATA controller completes CACHE FLUSH essentially
+/// instantly and does not reproduce the exact real-hardware timing race
+/// described in the issue (a fast real CPU sampling stale status right after
+/// the command-register write). This test can only prove the new code path
+/// is exercised, returns `Ok`, and preserves data end-to-end - it cannot by
+/// itself prove the 400 ns settle fixes a real-hardware race.
+#[test_case]
+fn test_ata_write_sectors_multi_sector_flush_path_preserves_data() {
+    ata::init();
+
+    const TEST_LBA: u32 = 2048;
+    const SECTOR_COUNT: u8 = 4;
+    const TOTAL_BYTES: usize = SECTOR_COUNT as usize * 512;
+
+    let mut original = [0u8; TOTAL_BYTES];
+    let mut read_back = [0u8; TOTAL_BYTES];
+    let mut pattern = [0u8; TOTAL_BYTES];
+
+    for (idx, byte) in pattern.iter_mut().enumerate() {
+        *byte = (idx as u8).wrapping_mul(83).wrapping_add(5);
+    }
+
+    let backup_result = ata::read_sectors(&mut original, TEST_LBA, SECTOR_COUNT);
+    assert!(
+        backup_result.is_ok(),
+        "precondition failed: backup read must succeed before flush-path write"
+    );
+
+    // This write exercises the post-write BSY-clear/error check and CACHE
+    // FLUSH added to `write_sectors`; it must return `Ok` rather than hang
+    // or error out on QEMU's virtual controller.
+    let write_result = ata::write_sectors(&pattern, TEST_LBA, SECTOR_COUNT);
+    assert!(
+        write_result.is_ok(),
+        "write_sectors must complete its post-write settle/flush and return Ok"
+    );
+
+    let read_result = ata::read_sectors(&mut read_back, TEST_LBA, SECTOR_COUNT);
+    assert!(read_result.is_ok(), "read after flushed write must succeed");
+
+    let matches = read_back == pattern;
+
+    let restore_result = ata::write_sectors(&original, TEST_LBA, SECTOR_COUNT);
+    assert!(
+        restore_result.is_ok(),
+        "test cleanup failed: original sectors must be restorable"
+    );
+
+    assert!(
+        matches,
+        "data read back after the flush path must match what was written"
+    );
+}
+
+/// Contract: repeated back-to-back write_sectors calls all succeed.
+///
+/// Given: ATA subsystem was initialized and a writable test sector is chosen.
+/// When: `write_sectors` is called several times in a row to the same LBA,
+///   each one running the new post-write completion-wait and CACHE FLUSH
+///   logic immediately after the previous call's flush completed.
+/// Then: Every call must return `Ok`, and the final write's data must be
+///   readable back correctly - i.e. one call's completion/flush wait does
+///   not leave the controller in a state that confuses the next command's
+///   400 ns settle/setup_command handshake.
+///
+/// Note: as above, this stresses the code path on QEMU's virtual
+/// controller; it demonstrates the new completion-wait/flush logic does
+/// not deadlock or corrupt state across repeated commands, but QEMU's
+/// timing does not reproduce the real-hardware race the issue describes.
+#[test_case]
+fn test_ata_write_sectors_back_to_back_calls_all_succeed() {
+    ata::init();
+
+    const TEST_LBA: u32 = 2048;
+    const ITERATIONS: usize = 5;
+
+    let mut original = [0u8; 512];
+    let backup_result = ata::read_sectors(&mut original, TEST_LBA, 1);
+    assert!(
+        backup_result.is_ok(),
+        "precondition failed: backup read must succeed before repeated writes"
+    );
+
+    let mut last_pattern = [0u8; 512];
+
+    for iteration in 0..ITERATIONS {
+        let mut pattern = [0u8; 512];
+        for (idx, byte) in pattern.iter_mut().enumerate() {
+            *byte = (idx as u8)
+                .wrapping_mul(13)
+                .wrapping_add(iteration as u8 * 7);
+        }
+
+        let write_result = ata::write_sectors(&pattern, TEST_LBA, 1);
+        assert!(
+            write_result.is_ok(),
+            "write_sectors iteration {} must complete its settle/flush and return Ok",
+            iteration
+        );
+
+        last_pattern = pattern;
+    }
+
+    let mut read_back = [0u8; 512];
+    let read_result = ata::read_sectors(&mut read_back, TEST_LBA, 1);
+    assert!(
+        read_result.is_ok(),
+        "read after repeated back-to-back writes must succeed"
+    );
+
+    let matches = read_back == last_pattern;
+
+    let restore_result = ata::write_sectors(&original, TEST_LBA, 1);
+    assert!(
+        restore_result.is_ok(),
+        "test cleanup failed: original sector must be restorable"
+    );
+
+    assert!(
+        matches,
+        "data after repeated back-to-back writes must match the last pattern written"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #12 (H6, HIGH severity) in `main64/kernel/src/drivers/ata.rs`:

1. **400 ns settle after issuing a command.** `AtaPio::setup_command` writes
   the command byte and previously returned immediately, letting
   `wait_ready_or_error` sample the real status register right away. On a
   fast real CPU the very first sample can observe stale `!BSY && DRQ` left
   over from the *previous* command, before the drive has had time to raise
   BSY for the new one. Fixed by adding a new control-block port
   `PRIMARY_CONTROL_BASE = 0x3F6` (a genuinely separate I/O base per the ATA
   spec, not an offset within the 0x1F0-0x1F7 command block) and a new
   `AtaPio::settle_after_command` helper that reads the alternate status
   register there four times (discarding the value) immediately after the
   command-byte write. Reading the alternate status register — unlike the
   regular status register — has no side effect of acknowledging a pending
   IRQ, so it's safe to use purely for timing.

2. **Post-write completion check + CACHE FLUSH.** `write_sectors` previously
   returned `Ok(())` right after pushing the last sector's data with no
   check that the drive actually accepted it, and never flushed the drive's
   write cache. Fixed by:
   - Adding a new `wait_completion_or_error()` free function (mirrors the
     existing `wait_ready_or_error`'s cooperative IRQ-hinted polling, but
     waits only for `!BSY` and checks `ERR`/`DF`, without requiring `DRQ`).
   - Calling it after the transfer loop to catch a device-reported error on
     the final sector before doing anything else.
   - Adding `AtaPio::issue_cache_flush()`, which writes `ATA_CMD_CACHE_FLUSH
     (0xE7)` to the command register (no need to re-select
     LBA/sector-count/drive-head per the ATA spec) and runs the same
     `settle_after_command` timing.
   - Calling `wait_completion_or_error()` again afterward to wait for the
     flush itself to finish before `write_sectors` returns.

## Test approach and limitations

Added two black-box `#[test_case]` tests to `tests/ata_test.rs` (existing
`Contract:/Given:/When:/Then:` style), both running against QEMU's emulated
primary ATA controller via `tests/test_runner.sh`:

- `test_ata_write_sectors_multi_sector_flush_path_preserves_data`: writes a
  4-sector pattern, reads it back, and restores the original data. Exercises
  the new post-write settle/flush path end-to-end without hanging or
  erroring, and confirms the flush path does not corrupt data.
- `test_ata_write_sectors_back_to_back_calls_all_succeed`: issues 5
  back-to-back `write_sectors` calls to the same LBA, each running the new
  completion-wait/flush logic, then verifies the final write's data is
  readable and the sector is correctly restored.

**Honesty about coverage**: these tests prove the new code path executes,
returns `Ok`, doesn't deadlock/hang, and preserves data correctness on
QEMU's virtual ATA controller. They do **not** reproduce the actual
real-hardware race described in the issue — QEMU's virtual controller
completes commands (including CACHE FLUSH) essentially instantly and
doesn't model the timing window where a fast real CPU could sample stale
status right after a command-register write. The 400 ns settle and
flush-completion logic are structurally correct per the ATA spec and this
file's existing patterns, but the specific race this issue describes is not
independently verifiable in this QEMU-based test environment.

## Gates run (all from `main64/kernel/` unless noted)

- `cargo clippy -- -D warnings` — clean, no warnings.
- `cargo clippy --test ata_test -- -D warnings` — clean, no warnings.
- `cargo fmt --check` (from `main64/`) — clean (ran `cargo fmt` once to fix
  test-file formatting, then verified clean).
- `cargo test --test ata_test` — **9/9 passed** (includes the 2 new tests).
- `cargo test --test ata_panic_contract_test` — **1/1 passed**, no
  regression in the pre-init panic contract.
- Full `cargo test` (all 36 integration test binaries) — **328/328 test
  cases passed**, no regressions elsewhere.

Closes #12