### PR TITLE
Fix H4: vfs::with() use-after-free by convention; mount/reset_mounted_fs un-gated

### DIFF
--- a/main64/kernel/src/io/vfs.rs
+++ b/main64/kernel/src/io/vfs.rs
@@ -3,6 +3,7 @@
 
 use crate::sync::spinlock::SpinLock;
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 /// Error conditions for filesystem facade operations.
@@ -63,11 +64,35 @@ pub trait FileSystem: Send + Sync {
     fn close_task_fds(&self, task_id: usize);
 }
 
-static MOUNTED_FS: SpinLock<Option<Box<dyn FileSystem>>> = SpinLock::new(None);
+// `Arc` (rather than `Box`) is load-bearing here: `with()` below must release
+// `MOUNTED_FS`'s spinlock before calling into the backend (see its doc comment),
+// which means it cannot keep borrowing through the guard. Cloning an `Arc` is a
+// cheap atomic refcount bump taken while the lock is held; the clone then keeps
+// the filesystem allocation alive independently of the global slot for as long
+// as the closure runs, even if `mount()`/`reset_mounted_fs()` replace the slot
+// concurrently. This makes the use-after-free that motivated this module
+// structurally impossible, without holding the lock across blocking disk I/O.
+static MOUNTED_FS: SpinLock<Option<Arc<dyn FileSystem>>> = SpinLock::new(None);
 
 /// Mount the active global filesystem. Call once during kernel boot path.
+///
+/// Write-once: if a filesystem is already mounted, this call is ignored and
+/// the existing mount is left in place. This prevents a stray or duplicate
+/// boot-path call from silently replacing (and dropping) a filesystem that
+/// other code may still be using, which is the production-facing half of the
+/// use-after-free concern this module guards against — see `with()` below for
+/// the other half (in-flight borrows surviving a concurrent mount/reset).
 pub fn mount(fs: Box<dyn FileSystem>) {
-    *MOUNTED_FS.lock() = Some(fs);
+    // Step 1: Take the lock and check whether a filesystem is already mounted.
+    let mut guard = MOUNTED_FS.lock();
+    if guard.is_some() {
+        crate::debugln!("vfs::mount: filesystem already mounted; ignoring redundant mount() call");
+        return;
+    }
+
+    // Step 2: First mount: convert the incoming `Box` into an `Arc` so `with()`
+    // can hand out cheap, independently-owned clones (see `MOUNTED_FS` above).
+    *guard = Some(Arc::from(fs));
 }
 
 /// Executes a closure with a stable shared reference to the mounted filesystem.
@@ -75,29 +100,30 @@ pub fn mount(fs: Box<dyn FileSystem>) {
 /// Thread-safe: releases the spinlock before invoking the closure so the
 /// backend file operations can block/yield without disabling interrupts.
 ///
-/// The mount lock (`MOUNTED_FS`) is never held across blocking
-/// disk I/O. The guard is dropped after copying a stable pointer to the
-/// filesystem backend; the backend itself uses interior mutability for its
-/// own descriptor tables and therefore does not rely on this outer lock.
+/// The mount lock (`MOUNTED_FS`) is never held across blocking disk I/O.
+/// Instead, the guard is used only to clone the `Arc<dyn FileSystem>` (a cheap
+/// atomic refcount bump), and is dropped before the backend call. The cloned
+/// `Arc` keeps the filesystem allocation alive for the duration of the
+/// closure regardless of what `mount()` or `reset_mounted_fs()` do to the
+/// global slot in the meantime — there is no dangling pointer to it, because
+/// no raw pointer into the slot is ever taken.
 fn with<R>(f: impl FnOnce(&dyn FileSystem) -> Result<R, FsError>) -> Result<R, FsError> {
-    // Step 1: Acquire the lock briefly to copy out the raw fat pointer to the trait object.
+    // Step 1: Acquire the lock briefly to clone out the Arc handle to the trait object.
     // Keep this critical section as short as possible; the backend call below
     // may yield (ATA/AHCI waits), so holding the mount lock here would deadlock
     // on single-core preemptive I/O.
-    let ptr: *const dyn FileSystem = {
+    let fs: Arc<dyn FileSystem> = {
         let guard = MOUNTED_FS.lock();
-        match guard.as_deref() {
-            Some(fs) => fs as *const dyn FileSystem,
+        match guard.as_ref() {
+            Some(fs) => Arc::clone(fs),
             None => return Err(FsError::NotMounted),
         }
     }; // The guard is dropped here, unlocking MOUNTED_FS and enabling interrupts.
 
-    // SAFETY:
-    // - `MOUNTED_FS` is a mount-once structure set during kernel boot and never replaced or freed.
-    // - The `Box` containing the traits object remains allocated for the entire kernel lifetime.
-    // - All backend implementations use interior mutability (such as spinlocks for descriptor tables),
-    //   safely allowing concurrent access through immutable references.
-    f(unsafe { &*ptr })
+    // No `unsafe` is required: `fs` is an owned `Arc` clone, so the reference
+    // handed to the closure is backed by this call's own refcount and remains
+    // valid for the closure's entire lifetime, independent of the global slot.
+    f(&*fs)
 }
 
 // Facade helpers used by syscalls and the loader.
@@ -158,7 +184,28 @@ pub fn close_task_fds(task_id: usize) {
     });
 }
 
-/// Reset the mounted filesystem to None (used for testing state isolation).
+/// Test-only reset of the mounted filesystem back to `None`.
+///
+/// Hidden from public docs; used by integration tests to isolate state
+/// between test cases so each can start from an unmounted VFS or remount a
+/// fresh backend (`mount()` is write-once in production, see above, and would
+/// otherwise reject a test's second `mount()` call).
+///
+/// Not gated behind `#[cfg(test)]`: this crate builds with `[lib] test = false`
+/// and integration tests under `tests/*.rs` link `kaos_kernel` as an ordinary
+/// (non-`--cfg test`) dependency, so `#[cfg(test)]` items in `src/` are never
+/// visible to them. `#[doc(hidden)]` plus this doc comment is the same
+/// test-only-escape-hatch convention already used elsewhere in this crate
+/// (e.g. `Fat32Volume::for_test`, `block::reset_active_device`,
+/// `scheduler::reset_initialization_for_test`).
+///
+/// Calling this from non-test code cannot reintroduce the use-after-free this
+/// module guards against: `with()` never holds a raw pointer into
+/// `MOUNTED_FS` across the closure, so even a misuse of this function while a
+/// `with()` call is in flight only drops the global slot's `Arc` handle — the
+/// clone held by the in-flight closure keeps the filesystem allocation alive
+/// until that closure returns.
+#[doc(hidden)]
 pub fn reset_mounted_fs() {
     *MOUNTED_FS.lock() = None;
 }

--- a/main64/kernel/tests/vfs_test.rs
+++ b/main64/kernel/tests/vfs_test.rs
@@ -9,8 +9,9 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use kaos_kernel::io::vfs::{self, FileMode, FsError};
+use kaos_kernel::io::vfs::{self, FileMode, FileSystem, FsError};
 use kaos_kernel::memory::{heap, pmm, vmm};
 
 /// Entry point for the VFS integration test kernel.
@@ -67,7 +68,12 @@ fn test_vfs_unmounted_returns_not_mounted() {
 /// Then: The call must return FsError::NotFound.
 #[test_case]
 fn test_vfs_mounted_open_missing_file_returns_not_found() {
-    // Step 1: Mount the FAT32 filesystem (superfloppy VBR at LBA 0).
+    // Step 1: Reset any FS left mounted by a previous test, then mount the FAT32
+    // filesystem (superfloppy VBR at LBA 0). The reset is required because `mount()`
+    // is write-once in production (see vfs.rs) and would otherwise silently ignore
+    // this call if a previous test (in this same QEMU boot/test binary) left a
+    // filesystem mounted, regardless of `#[test_case]` execution order.
+    vfs::reset_mounted_fs();
     let vol = kaos_kernel::io::fat32::Fat32Volume::mount(0).expect("FAT32 must mount at LBA 0");
     vfs::mount(Box::new(kaos_kernel::io::fat32::Fat32Fs::new(vol)));
 
@@ -88,7 +94,11 @@ fn test_vfs_mounted_open_missing_file_returns_not_found() {
 /// fd check because FAT32 is read-only.
 #[test_case]
 fn test_vfs_invalid_fd_returns_invalid_fd() {
-    // Step 1: Mount the FAT32 filesystem (superfloppy VBR at LBA 0).
+    // Step 1: Reset any FS left mounted by a previous test, then mount the FAT32
+    // filesystem (superfloppy VBR at LBA 0). See the comment in
+    // `test_vfs_mounted_open_missing_file_returns_not_found` for why the reset is
+    // required now that `mount()` is write-once.
+    vfs::reset_mounted_fs();
     let vol = kaos_kernel::io::fat32::Fat32Volume::mount(0).expect("FAT32 must mount at LBA 0");
     vfs::mount(Box::new(kaos_kernel::io::fat32::Fat32Fs::new(vol)));
 
@@ -115,5 +125,130 @@ fn test_vfs_invalid_fd_returns_invalid_fd() {
     assert!(
         matches!(vfs::eof(bad_fd), Err(FsError::InvalidFd)),
         "eof must reject invalid fd"
+    );
+}
+
+/// Minimal `FileSystem` test double whose `open()` returns a caller-chosen
+/// marker value as the "file descriptor". Used below to tell, from the
+/// outside, which of two mounted instances is actually backing the facade
+/// (the real `Fat32Fs` gives no such externally observable identity).
+struct MarkerFs {
+    marker: usize,
+}
+
+impl FileSystem for MarkerFs {
+    fn open(&self, _name: &str, _mode: FileMode) -> Result<usize, FsError> {
+        Ok(self.marker)
+    }
+
+    fn close(&self, _fd: usize) -> Result<(), FsError> {
+        Ok(())
+    }
+
+    fn read(&self, _fd: usize, _buf: &mut [u8]) -> Result<usize, FsError> {
+        Ok(0)
+    }
+
+    fn write(&self, _fd: usize, _buf: &[u8]) -> Result<usize, FsError> {
+        Err(FsError::Unsupported)
+    }
+
+    fn seek(&self, _fd: usize, _offset: u32) -> Result<(), FsError> {
+        Ok(())
+    }
+
+    fn eof(&self, _fd: usize) -> Result<bool, FsError> {
+        Ok(true)
+    }
+
+    fn delete(&self, _name: &str) -> Result<(), FsError> {
+        Err(FsError::Unsupported)
+    }
+
+    fn read_file(&self, _name: &str) -> Result<Vec<u8>, FsError> {
+        Ok(Vec::new())
+    }
+
+    fn print_root_directory(&self) {}
+
+    fn close_task_fds(&self, _task_id: usize) {}
+}
+
+/// Contract: `mount()` is write-once — once a filesystem is mounted, a second
+/// `mount()` call must not replace (and therefore cannot drop) the active one.
+/// Given: No filesystem is mounted.
+/// When: `mount()` is called twice in a row with two distinguishable backends.
+/// Then: The facade must keep dispatching to the *first* backend; the second
+/// `mount()` call must be a no-op.
+///
+/// What this proves vs. what's structurally guaranteed: this is a single-core,
+/// cooperative test harness with no real concurrent callers, so it cannot
+/// reproduce the original racing mount/with() scenario from the issue
+/// end-to-end. What it does concretely verify is the write-once guard in
+/// `mount()` itself — the production-facing half of the fix. The other half
+/// (an in-flight `with()` borrow surviving a concurrent mount/reset) is no
+/// longer reachable by construction, because `with()` operates on an owned
+/// `Arc` clone rather than a raw pointer into the global slot; that part is
+/// guaranteed by `Arc`'s refcounting semantics, not by anything a
+/// single-threaded test can directly exercise.
+#[test_case]
+fn test_vfs_mount_is_write_once() {
+    // Step 1: Start from a clean, unmounted state.
+    vfs::reset_mounted_fs();
+
+    // Step 2: Mount the first backend, then attempt to mount a second, distinct
+    // backend on top of it.
+    vfs::mount(Box::new(MarkerFs { marker: 111 }));
+    vfs::mount(Box::new(MarkerFs { marker: 222 }));
+
+    // Step 3: The facade must still be dispatching to the first backend.
+    let fd = vfs::open("whatever", FileMode::Read)
+        .expect("open must succeed once a filesystem is mounted");
+    assert_eq!(
+        fd, 111,
+        "a second mount() call must be ignored; the originally mounted FS must remain active"
+    );
+
+    // Step 4: Leave the global mount state clean for whichever test runs next
+    // (execution order across #[test_case] functions is not guaranteed).
+    vfs::reset_mounted_fs();
+}
+
+/// Contract: the mounted filesystem stays valid and usable across a
+/// reset+remount cycle; the reset does not leave the facade in a broken or
+/// stale state.
+/// Given: A FAT32 filesystem is mounted and a known file can be read from it.
+/// When: The mount is reset to `None` and then a fresh FAT32 volume is mounted
+/// again.
+/// Then: The facade must report `NotMounted` while reset, and must again
+/// successfully read the same file once remounted, with matching content.
+#[test_case]
+fn test_vfs_reset_and_remount_cycle() {
+    // Step 1: Mount the FAT32 filesystem and confirm a known file is readable.
+    vfs::reset_mounted_fs();
+    let vol = kaos_kernel::io::fat32::Fat32Volume::mount(0).expect("FAT32 must mount at LBA 0");
+    vfs::mount(Box::new(kaos_kernel::io::fat32::Fat32Fs::new(vol)));
+    let first_read =
+        vfs::read_file("HELLO.BIN").expect("HELLO.BIN must be readable on the first mount");
+    assert!(!first_read.is_empty(), "HELLO.BIN must not be empty");
+
+    // Step 2: Reset the mount and confirm the facade reports NotMounted.
+    vfs::reset_mounted_fs();
+    assert!(
+        matches!(vfs::read_file("HELLO.BIN"), Err(FsError::NotMounted)),
+        "read_file must return NotMounted immediately after reset_mounted_fs()"
+    );
+
+    // Step 3: Remount a fresh volume and confirm the same file reads back
+    // identically, proving the facade is fully usable again (not left in a
+    // half-torn-down state by the reset).
+    let vol_again =
+        kaos_kernel::io::fat32::Fat32Volume::mount(0).expect("FAT32 must remount at LBA 0");
+    vfs::mount(Box::new(kaos_kernel::io::fat32::Fat32Fs::new(vol_again)));
+    let second_read =
+        vfs::read_file("HELLO.BIN").expect("HELLO.BIN must be readable again after remount");
+    assert_eq!(
+        first_read, second_read,
+        "file contents must be identical across the reset+remount cycle"
     );
 }


### PR DESCRIPTION
## Summary

`vfs::with()` copied a `*const dyn FileSystem` out from under the `MOUNTED_FS` spinlock, dropped the guard, then dereferenced the raw pointer (`unsafe { &*ptr }`). Both `mount()` and `reset_mounted_fs()` could free the underlying `Box` while a `with()` closure was still executing (e.g. across a blocking ATA/AHCI read), which would dangle the pointer.

### Fix: `Arc` instead of a raw pointer (structural fix, not a convention)

`MOUNTED_FS` now holds `Option<Arc<dyn FileSystem>>` instead of `Option<Box<dyn FileSystem>>`. `with()` clones the `Arc` (a cheap atomic refcount bump) while the lock is held, then drops the lock before invoking the closure — same critical-section shape as before, no more blocking-I/O-under-lock deadlock risk. But now the closure runs against an **owned** `Arc` clone: even if `mount()`/`reset_mounted_fs()` replace or clear the global slot concurrently, the clone keeps the `FileSystem` allocation alive until the closure returns. No raw pointer is ever taken into the slot, so the original UAF is impossible by construction, not just by convention. All `unsafe` in this path is removed.

### `mount()` is now write-once

A second `mount()` call is ignored (logged via `debugln!`) instead of silently replacing — and dropping — a filesystem another part of the kernel may still be using. This is the production-facing half of "mount is write-once at boot" from the issue's fix plan. All three call sites (`main.rs` BIOS/UEFI branches, which are mutually exclusive `if`/`else` arms) are unaffected.

### `reset_mounted_fs()` reachability

The issue's fix plan suggested `#[cfg(test)]`. That doesn't work here: this crate has `[lib] test = false`, and integration tests in `tests/*.rs` link `kaos_kernel` as an ordinary (non-`--cfg test`) dependency, so `#[cfg(test)]` items in `src/` are invisible to them — gating this way would silently break `tests/vfs_test.rs` (and `block_test.rs`'s analogous `reset_active_device`, `process_contract_test.rs`'s `reset_initialization_for_test`).

Instead, `reset_mounted_fs()` keeps the `#[doc(hidden)] pub fn` "test-only escape hatch" shape already used by this codebase for the same problem (`Fat32Volume::for_test`, `block::reset_active_device`, `scheduler::reset_initialization_for_test`) — not compiler-enforced, but clearly named and documented as test-only, consistent with existing precedent. Achieving actual compiler-enforced unreachability from production code would need a Cargo feature-flag split that ripples into every build script in `build/*.sh`; that's out of scope for this fix and not worth the churn given the Arc change already makes the *actual* UAF impossible regardless of whether `reset_mounted_fs()` is technically reachable.

## Tests added (`kernel/tests/vfs_test.rs`)

- `test_vfs_mount_is_write_once`: mounts two distinguishable `FileSystem` test doubles (`MarkerFs`, added to the test file) back-to-back and asserts the facade still dispatches to the first one — concretely verifies the write-once guard in `mount()`.
- `test_vfs_reset_and_remount_cycle`: mounts FAT32, reads a known file, resets, confirms `NotMounted`, remounts, and confirms the same file reads back identical content — verifies the facade isn't left in a half-torn-down state across a reset+remount cycle.

Honesty note: this is a single-core, cooperative test harness with no real concurrent callers, so neither test reproduces the original racing mount/`with()` scenario end-to-end. What's concretely tested is the write-once guard and reset/remount behavior; the actual UAF-impossibility is a structural guarantee of `Arc`'s refcounting, not something a single-threaded test can directly exercise.

Also updated the two existing tests that call `mount()` (`test_vfs_mounted_open_missing_file_returns_not_found`, `test_vfs_invalid_fd_returns_invalid_fd`) to call `reset_mounted_fs()` first, since `#[test_case]` execution order is not declaration order (confirmed empirically — this test binary runs tests alphabetically) and mount()'s new write-once semantics mean a stale mount from a differently-ordered test would otherwise make their `mount()` calls silently no-op.

## Gates run (from `main64/kernel/` unless noted)

- `cargo clippy -- -D warnings` — clean.
- `cargo clippy --test vfs_test -- -D warnings` — clean.
- `cargo fmt --check` (from `main64/`) — clean.
- `cargo test --test vfs_test` — **5/5 passed** (includes the 2 new tests).
- Full `cargo test` (all 36 integration test binaries) — **328/328 test cases passed**, no regressions.

Closes #10