### PR TITLE
Fix H5: FAT32 cluster chains have no cycle detection (1e6-read DoS)

### DIFF
--- a/main64/kernel/src/io/fat32.rs
+++ b/main64/kernel/src/io/fat32.rs
@@ -160,13 +160,16 @@ impl Fat32Volume {
 
         // Step 2: Walk the root-directory cluster chain
         // We traverse the directory clusters to find our target file. We use a safety
-        // counter `cluster_count` to prevent infinite loops in case the FAT chain is corrupted.
+        // counter `cluster_count` bounded by the volume's actual cluster count
+        // (`max_data_cluster`) to detect infinite loops in case the FAT chain is corrupted.
+        // A valid, acyclic chain can visit at most `max_data_cluster` distinct clusters, so
+        // exceeding that count proves the chain is cyclic (e.g. a crafted A->B->A loop) and
+        // we abort immediately instead of following it for up to a huge hardcoded iteration
+        // cap, each iteration of which performs real disk reads.
         let mut cluster_count = 0;
         'dir_walk: while (2..0x0FFF_FFF8).contains(&current_cluster) {
             cluster_count += 1;
-            if cluster_count > 1_000_000 {
-                return Err(Fat32Error::BadChain);
-            }
+            self.check_chain_bound(cluster_count)?;
 
             // For each cluster, we read all its sectors sequentially.
             // Reject clusters outside the volume bounds before translating them to LBAs.
@@ -238,16 +241,16 @@ impl Fat32Volume {
 
         // Step 4: Walk the file's cluster chain
         // We follow the file's cluster chain, copying data into our `Vec` until we have
-        // read exactly `target_file_size` bytes. The loop is similarly guarded against corruption.
+        // read exactly `target_file_size` bytes. The loop is similarly guarded against
+        // corruption by `check_chain_bound`, which rejects chains longer than the volume's
+        // actual cluster count as necessarily cyclic.
         let mut content = Vec::with_capacity(target_file_size as usize);
         let mut current_cluster = target_first_cluster;
         let mut cluster_count = 0;
 
         while (2..0x0FFF_FFF8).contains(&current_cluster) {
             cluster_count += 1;
-            if cluster_count > 1_000_000 {
-                return Err(Fat32Error::BadChain);
-            }
+            self.check_chain_bound(cluster_count)?;
 
             // For each cluster, read its sectors and append their bytes to our buffer.
             // Reject clusters outside the volume bounds before translating them to LBAs.
@@ -290,9 +293,12 @@ impl Fat32Volume {
             let mut cluster_count = 0;
 
             // Step 1: Walk the root directory cluster chain
+            // Bounded by `check_chain_bound`, which rejects chains longer than the volume's
+            // actual cluster count (`max_data_cluster`) as necessarily cyclic. This is a
+            // best-effort listing, so we simply stop instead of returning an error.
             'dir_walk: while (2..0x0FFF_FFF8).contains(&current_cluster) {
                 cluster_count += 1;
-                if cluster_count > 1_000_000 {
+                if self.check_chain_bound(cluster_count).is_err() {
                     break;
                 }
 
@@ -410,6 +416,25 @@ impl Fat32Volume {
         Ok(self.data_start_lba + (cluster as u64 - 2) * self.sec_per_clus as u64)
     }
 
+    /// Bounds the number of clusters a chain-follow loop may visit.
+    ///
+    /// `next_cluster` only validates a single FAT entry in isolation (range, EOC, bad-cluster
+    /// marker) — it cannot detect a cycle, since every individual entry in a cyclic chain
+    /// (e.g. a crafted `A -> B -> A` loop) is perfectly well-formed on its own. Instead, every
+    /// chain-follow loop counts the clusters it has visited and calls this helper on each
+    /// iteration. Since a structurally valid, acyclic chain can visit each of the volume's
+    /// `max_data_cluster` data clusters at most once, a chain that visits more clusters than
+    /// exist in the volume is necessarily cyclic, and we return `BadChain` immediately instead
+    /// of continuing to follow it — previously this was only bounded by a hardcoded
+    /// 1,000,000-iteration cap, allowing a crafted 2-cluster cycle to force up to ~1e6 real
+    /// sector reads before failing.
+    fn check_chain_bound(&self, cluster_count: u32) -> Result<(), Fat32Error> {
+        if cluster_count > self.max_data_cluster {
+            return Err(Fat32Error::BadChain);
+        }
+        Ok(())
+    }
+
     /// Helper to look up the next cluster in the FAT chain.
     // SAFETY:
     // - computes the FAT sector and offset correctly for FAT32
@@ -475,6 +500,34 @@ impl Fat32Volume {
     #[doc(hidden)]
     pub fn cluster_to_lba_for_test(&self, cluster: u32) -> Result<u64, Fat32Error> {
         self.cluster_to_lba(cluster)
+    }
+
+    /// Test-only wrapper around `next_cluster`.
+    #[doc(hidden)]
+    pub fn next_cluster_for_test(&self, cluster: u32) -> Result<u32, Fat32Error> {
+        self.next_cluster(cluster)
+    }
+
+    /// Test-only chain-follow helper that reuses the exact same production bound check
+    /// (`check_chain_bound`) and cluster lookup (`next_cluster`) used by `read_file` and
+    /// `print_root_directory`, without requiring a full directory/file setup.
+    ///
+    /// Returns the number of clusters visited once the chain terminates (hits an EOC
+    /// marker), or propagates `Err(Fat32Error::BadChain)` if the bound derived from
+    /// `max_data_cluster` is exceeded (i.e. the chain is cyclic) or a FAT entry is otherwise
+    /// invalid.
+    #[doc(hidden)]
+    pub fn walk_chain_for_test(&self, start_cluster: u32) -> Result<u32, Fat32Error> {
+        let mut current_cluster = start_cluster;
+        let mut cluster_count = 0;
+
+        while (2..0x0FFF_FFF8).contains(&current_cluster) {
+            cluster_count += 1;
+            self.check_chain_bound(cluster_count)?;
+            current_cluster = self.next_cluster(current_cluster)?;
+        }
+
+        Ok(cluster_count)
     }
 }
 

--- a/main64/kernel/tests/fat32_test.rs
+++ b/main64/kernel/tests/fat32_test.rs
@@ -9,6 +9,7 @@
 #![reexport_test_harness_main = "test_main"]
 
 use core::panic::PanicInfo;
+use kaos_kernel::drivers::block;
 use kaos_kernel::io::fat32;
 
 /// Entry point for the integration test kernel.
@@ -71,4 +72,71 @@ fn test_cluster_to_lba_rejects_out_of_range_clusters() {
 
     // Cluster 6 is beyond max_data_cluster and must be rejected immediately.
     assert!(volume.cluster_to_lba_for_test(6).is_err());
+}
+
+/// Contract (H5, Closes #11): chain-follow loops must bound chain length by the volume's
+/// actual cluster count (`max_data_cluster`), not by a hardcoded 1,000,000-iteration cap.
+/// A chain longer than the volume's cluster count is necessarily cyclic, since a valid,
+/// acyclic chain can visit each existing data cluster at most once.
+/// Given: A synthetic FAT32 volume with `max_data_cluster = 4`, whose on-disk FAT contains
+/// a crafted 2-cluster cycle: cluster 2's entry points to cluster 3, and cluster 3's entry
+/// points back to cluster 2. Every individual FAT entry involved is structurally valid (in
+/// range, not an EOC marker, not the bad-cluster marker), so a per-entry check alone
+/// (`next_cluster`) cannot detect the loop -- only bounding the total clusters visited can.
+/// When: The chain starting at cluster 2 is followed via `walk_chain_for_test`, which reuses
+/// the same `check_chain_bound`/`next_cluster` logic as the production `read_file` and
+/// `print_root_directory` loops.
+/// Then: The walk returns `Err(Fat32Error::BadChain)` after visiting at most
+/// `max_data_cluster` (4) clusters -- i.e. within `cluster_count` iterations, never anywhere
+/// near the old 1,000,000-iteration / real-disk-read cap.
+#[test_case]
+fn test_cyclic_fat_chain_returns_bad_chain_within_cluster_count() {
+    // Step 1: Initialize the ATA block device so `next_cluster`'s real FAT sector reads
+    // (and our own crafted write below) actually reach the QEMU disk image.
+    kaos_kernel::drivers::ata::init();
+    block::init_ata();
+
+    // Step 2: Pick a scratch LBA far past anything the test disk image's real FAT32
+    // filesystem (built by tests/test_runner.sh from a 64 MiB image) ever writes to, so we
+    // can freely overwrite it with a synthetic, deliberately cyclic FAT without disturbing
+    // the real mounted filesystem/files used by other integration tests.
+    const SCRATCH_FAT_LBA: u64 = 125_000;
+
+    // Step 3: Craft a single FAT sector where cluster 2's 4-byte entry (byte offset 8) points
+    // to cluster 3, and cluster 3's entry (byte offset 12) points back to cluster 2 -- a
+    // 2-cluster cycle (A -> B -> A) that passes every per-entry validity check forever.
+    let mut fat_sector = [0u8; 512];
+    fat_sector[8..12].copy_from_slice(&3u32.to_le_bytes());
+    fat_sector[12..16].copy_from_slice(&2u32.to_le_bytes());
+    block::write_sectors(SCRATCH_FAT_LBA, 1, &fat_sector)
+        .expect("writing the synthetic cyclic FAT sector must succeed");
+
+    // Step 4: Build a synthetic volume whose FAT starts at our scratch sector, with a
+    // deliberately tiny max_data_cluster (4). The data region is never touched by this test
+    // (chain-following only reads FAT sectors), so data_start_lba/sec_per_clus/root_cluster
+    // are placeholders.
+    let volume = fat32::Fat32Volume::for_test(
+        0,                   // part_lba (unused: not read by next_cluster/for_test)
+        512,                 // bytes_per_sec
+        1,                   // sec_per_clus (unused: data region is never read here)
+        SCRATCH_FAT_LBA,     // fat_start_lba
+        SCRATCH_FAT_LBA + 1, // data_start_lba (unused placeholder)
+        2,                   // root_cluster (unused: we start the walk explicitly)
+        4,                   // max_data_cluster
+    );
+
+    // Step 5: Confirm cluster 2 and cluster 3 both individually pass as valid, distinct FAT
+    // entries -- demonstrating exactly why a per-entry check alone cannot detect this cycle.
+    assert_eq!(volume.next_cluster_for_test(2).unwrap(), 3);
+    assert_eq!(volume.next_cluster_for_test(3).unwrap(), 2);
+
+    // Step 6: Follow the cycle through the same bound-checked path used by production code.
+    // With max_data_cluster = 4, a correct fix must report BadChain after visiting at most
+    // 4 clusters (5 next_cluster calls), not after up to 1,000,000 real disk reads.
+    let result = volume.walk_chain_for_test(2);
+    assert!(
+        matches!(result, Err(fat32::Fat32Error::BadChain)),
+        "a cyclic FAT chain must be reported as BadChain instead of looping forever, got {:?}",
+        result
+    );
 }


### PR DESCRIPTION
## Summary

Fixes issue #11 (H5, HIGH severity). All three FAT32 chain-follow loops in `main64/kernel/src/io/fat32.rs` (the directory-walk and file-chain-walk loops in `read_file`, and the directory-walk loop in `print_root_directory`) were guarded only by a hardcoded 1,000,000-iteration counter. Per-entry FAT validation (`next_cluster`) checks range/EOC/bad-cluster markers, but cannot detect a *revisit* — every entry in a cyclic chain is individually well-formed. A crafted 2-cluster cycle (`A -> B -> A`) therefore passed every per-entry check and could force up to ~1,000,000 real sector reads before finally failing with `BadChain` — a disk-I/O amplification DoS.

**Fix:** bound each chain-follow loop by the volume's actual cluster count (`max_data_cluster`, computed from the BPB at mount time) instead of the hardcoded constant. A structurally valid, acyclic chain can visit each of the volume's existing data clusters at most once, so a chain that visits more clusters than exist in the volume is necessarily cyclic, and `BadChain` is now returned immediately.

The bound check was extracted into a single shared `check_chain_bound` helper reused by all three call sites (rather than duplicating the increment/compare in three places), which also keeps future callers from re-introducing a divergent hardcoded cap.

## Test construction

Added `test_cyclic_fat_chain_returns_bad_chain_within_cluster_count` to `tests/fat32_test.rs`, following its existing `Contract:/Given:/When:/Then:` doc-comment convention:

1. Initializes the ATA block device (`ata::init()` + `block::init_ata()`), matching the pattern already used in `tests/block_test.rs`.
2. Builds a synthetic `Fat32Volume` via the existing `for_test` seam, pointing `fat_start_lba` at a scratch sector (LBA 125,000) far past anything the real test FAT32 image (built by `tests/test_runner.sh`) ever writes, with a deliberately tiny `max_data_cluster = 4`.
3. Writes a crafted FAT sector via `block::write_sectors` where cluster 2's entry points to cluster 3, and cluster 3's entry points back to cluster 2 — a genuine 2-cluster on-disk cycle.
4. Adds two new test-only wrappers (matching the existing `#[doc(hidden)] pub fn ..._for_test` convention): `next_cluster_for_test` (confirms both cluster 2 and 3 individually pass as valid, distinct FAT entries — demonstrating why a per-entry check alone can't catch this) and `walk_chain_for_test`, which reuses the exact same `check_chain_bound`/`next_cluster` production logic as `read_file`/`print_root_directory`, so the test exercises the real fix rather than a reimplementation of it.
5. Asserts `walk_chain_for_test(2)` returns `Err(Fat32Error::BadChain)` — which, given `max_data_cluster = 4`, can only happen after at most 4 clusters visited (5 `next_cluster` calls), not after up to 1,000,000 real disk reads.

## Gates run (all from `main64/kernel/` unless noted)

- `cargo clippy -- -D warnings` — clean, no warnings.
- `cargo clippy --test fat32_test -- -D warnings` — clean, no warnings.
- `cargo fmt --check` (from `main64/`) — clean, no diff.
- `cargo test --test fat32_test` — **passed**, 4/4 test cases (includes the new cyclic-FAT regression test).
- Full `cargo test` (all 36 integration test binaries) — **passed**, 327/327 test cases, no regressions.

Closes #11