### PR TITLE
fix(io/gpt): distinguish GPT failure modes in fallback_esp (M5)

### DIFF
--- a/main64/docs/storage.md
+++ b/main64/docs/storage.md
@@ -366,9 +366,9 @@ Only the UEFI path needs this. A GPT disk has a header at **LBA 1** (signature
 3. On a match, returns the partition's starting LBA (entry offset `0x20`), which
    becomes the FAT32 mount's `part_lba`.
 
-If parsing fails or no ESP is found, `fallback_esp()` returns **LBA 2048** (the
-conventional first-partition offset) — a pragmatic fallback flagged with a TODO to
-remove once GPT parsing is fully trusted.
+If a valid GPT header and partition table are present but contain no ESP entry, `fallback_esp()`
+returns **LBA 2048** (the conventional first-partition offset) with a log message. If the GPT is
+unreadable or absent, `find_esp_start_lba()` returns `None`.
 
 ---
 

--- a/main64/kernel/src/drivers/block.rs
+++ b/main64/kernel/src/drivers/block.rs
@@ -218,3 +218,8 @@ pub fn write_sectors(lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError>
 pub fn reset_active_device() {
     *ACTIVE_DEVICE.lock() = None;
 }
+
+/// Set a custom active block device (used for testing).
+pub fn set_active_device(device: &'static dyn BlockDevice) {
+    *ACTIVE_DEVICE.lock() = Some(device);
+}

--- a/main64/kernel/src/io/gpt.rs
+++ b/main64/kernel/src/io/gpt.rs
@@ -7,23 +7,28 @@ const ESP_TYPE_GUID: [u8; 16] = [
     0x28, 0x73, 0x2A, 0xC1, 0x1F, 0xF8, 0xD2, 0x11, 0xBA, 0x4B, 0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B,
 ];
 
-/// Returns the starting LBA of the EFI System Partition, or None if not found.
+/// Returns the starting LBA of the EFI System Partition, or None if the GPT is unreadable or absent.
 ///
 /// Reads the GPT header at LBA 1, then iterates through partition entries looking
-/// for the ESP type GUID.
+/// for the ESP type GUID. If a valid GPT header and partition entries are present but contain
+/// no ESP entry, falls back to LBA 2048 with a log message.
 pub fn find_esp_start_lba() -> Option<u64> {
     let mut header_sector = [0u8; 512];
 
     // Step 1: Read LBA 1 to find the GPT header.
-    // We expect the AHCI driver to succeed in reading this sector.
+    // We expect the block device driver to succeed in reading this sector.
     if block::read_sectors(1, 1, &mut header_sector).is_err() {
-        return fallback_esp();
+        crate::debugln!("GPT: failed to read header sector at LBA 1");
+        return None;
     }
 
     // Step 2: Parse the header to get partition array metadata.
     let (entry_lba, num_entries, entry_size) = match parse_gpt_header(&header_sector) {
         Some(info) => info,
-        None => return fallback_esp(),
+        None => {
+            crate::debugln!("GPT: invalid signature or header at LBA 1");
+            return None;
+        }
     };
 
     // Determine how many entries fit in one sector.
@@ -41,7 +46,8 @@ pub fn find_esp_start_lba() -> Option<u64> {
         let lba = (entry_lba + sector_offset as u64) as u32;
 
         if block::read_sectors(lba as u64, 1, &mut entry_sector).is_err() {
-            return fallback_esp();
+            crate::debugln!("GPT: failed to read partition entry sector at LBA {}", lba);
+            return None;
         }
 
         let entries_in_this_sector = core::cmp::min(
@@ -56,7 +62,7 @@ pub fn find_esp_start_lba() -> Option<u64> {
         }
     }
 
-    // None matched.
+    // Valid GPT header present and entries checked, but no ESP entry matched.
     fallback_esp()
 }
 
@@ -101,9 +107,9 @@ pub fn parse_gpt_entries_sector(
     None
 }
 
-/// Fallback if parsing fails or ESP is not found.
+/// Fallback when a valid GPT is present but no ESP entry was found.
 /// TODO: remove fallback once the primary GPT parsing path is fully stabilized.
 fn fallback_esp() -> Option<u64> {
-    crate::debugln!("ESP not found in GPT, falling back to LBA 2048");
+    crate::debugln!("GPT: valid GPT found but no ESP entry present, falling back to LBA 2048");
     Some(2048)
 }

--- a/main64/kernel/tests/gpt_test.rs
+++ b/main64/kernel/tests/gpt_test.rs
@@ -103,3 +103,134 @@ fn test_parse_gpt_entries_sector_not_found() {
     let result = gpt::parse_gpt_entries_sector(&sector, 4, entry_size);
     assert_eq!(result, None);
 }
+
+// ============================================================================
+// find_esp_start_lba Integration Tests
+// ============================================================================
+
+use kaos_kernel::drivers::block::{self, BlockDevice, BlockError};
+use kaos_kernel::sync::spinlock::SpinLock;
+
+struct DynamicMockBlockDevice {
+    fail_lba1: SpinLock<bool>,
+    fail_entry: SpinLock<bool>,
+    header_sector: SpinLock<[u8; 512]>,
+    entry_sector: SpinLock<[u8; 512]>,
+}
+
+impl DynamicMockBlockDevice {
+    const fn new() -> Self {
+        Self {
+            fail_lba1: SpinLock::new(false),
+            fail_entry: SpinLock::new(false),
+            header_sector: SpinLock::new([0u8; 512]),
+            entry_sector: SpinLock::new([0u8; 512]),
+        }
+    }
+
+    fn reset(&self) {
+        *self.fail_lba1.lock() = false;
+        *self.fail_entry.lock() = false;
+        *self.header_sector.lock() = [0u8; 512];
+        *self.entry_sector.lock() = [0u8; 512];
+    }
+
+    fn setup_valid_header(&self, entry_lba: u64, num_entries: u32, entry_size: u32) {
+        let mut hdr = [0u8; 512];
+        hdr[0..8].copy_from_slice(b"EFI PART");
+        hdr[0x48..0x50].copy_from_slice(&entry_lba.to_le_bytes());
+        hdr[0x50..0x54].copy_from_slice(&num_entries.to_le_bytes());
+        hdr[0x54..0x58].copy_from_slice(&entry_size.to_le_bytes());
+        *self.header_sector.lock() = hdr;
+    }
+}
+
+impl BlockDevice for DynamicMockBlockDevice {
+    fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
+        if count != 1 || buf.len() < 512 {
+            return Err(BlockError::BadBuffer);
+        }
+        if lba == 1 {
+            if *self.fail_lba1.lock() {
+                return Err(BlockError::Device);
+            }
+            buf[..512].copy_from_slice(&*self.header_sector.lock());
+            Ok(())
+        } else {
+            if *self.fail_entry.lock() {
+                return Err(BlockError::Device);
+            }
+            buf[..512].copy_from_slice(&*self.entry_sector.lock());
+            Ok(())
+        }
+    }
+
+    fn write_sectors(&self, _lba: u64, _count: u32, _buf: &[u8]) -> Result<(), BlockError> {
+        Err(BlockError::Unsupported)
+    }
+}
+
+static TEST_MOCK_DEV: DynamicMockBlockDevice = DynamicMockBlockDevice::new();
+
+#[test_case]
+fn test_find_esp_start_lba_unreadable_header() {
+    TEST_MOCK_DEV.reset();
+    *TEST_MOCK_DEV.fail_lba1.lock() = true;
+    block::set_active_device(&TEST_MOCK_DEV);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_invalid_signature() {
+    TEST_MOCK_DEV.reset();
+    // Header is zeroed (invalid signature)
+    block::set_active_device(&TEST_MOCK_DEV);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_unreadable_entry_sector() {
+    TEST_MOCK_DEV.reset();
+    TEST_MOCK_DEV.setup_valid_header(2, 128, 128);
+    *TEST_MOCK_DEV.fail_entry.lock() = true;
+    block::set_active_device(&TEST_MOCK_DEV);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_valid_gpt_no_esp_entry() {
+    TEST_MOCK_DEV.reset();
+    TEST_MOCK_DEV.setup_valid_header(2, 128, 128);
+    // Entry sector is zeroed (no matching ESP GUID)
+    block::set_active_device(&TEST_MOCK_DEV);
+
+    assert_eq!(gpt::find_esp_start_lba(), Some(2048));
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_valid_gpt_with_esp() {
+    TEST_MOCK_DEV.reset();
+    TEST_MOCK_DEV.setup_valid_header(2, 128, 128);
+
+    let mut entry_sec = [0u8; 512];
+    entry_sec[0..16].copy_from_slice(&ESP_TYPE_GUID);
+    entry_sec[0x20..0x28].copy_from_slice(&4096u64.to_le_bytes());
+    *TEST_MOCK_DEV.entry_sector.lock() = entry_sec;
+
+    block::set_active_device(&TEST_MOCK_DEV);
+
+    assert_eq!(gpt::find_esp_start_lba(), Some(4096));
+
+    block::reset_active_device();
+}


### PR DESCRIPTION
Closes #17

## Problem

`fallback_esp()` previously returned `Some(2048)` for **all** failure cases — a read error on LBA 1, an invalid/missing GPT signature, a failed partition entry sector read, and a genuine "valid GPT but no ESP partition" — making it impossible for callers to distinguish "disk is unreadable/has no GPT" from "GPT found, no ESP declared". Every failure silently aliased to LBA 2048.

## Fix

- **Read failure (LBA 1)**: Now logs `"GPT: failed to read header sector at LBA 1"` and returns `None`.
- **Missing/invalid GPT magic**: Now logs `"GPT: invalid signature or header at LBA 1"` and returns `None`.
- **Partition entry sector read failure**: Now logs `"GPT: failed to read partition entry sector at LBA {lba}"` and returns `None`.
- **Valid GPT, no ESP entry found**: The only case that still returns `Some(2048)`, now with log `"GPT: valid GPT found but no ESP entry present, falling back to LBA 2048"`.
- `fallback_esp()` is now called only from the final case, with its doc comment updated to make the intent explicit.
- The `find_esp_start_lba()` doc comment is updated to document all four outcomes.

## Caller impact

`main.rs` uses `.expect("ESP not found on GPT disk")` which correctly propagates `None` as a kernel panic. No behavioral change on healthy hardware; broken disks now correctly panic instead of silently attempting to mount a non-existent FAT32 partition at LBA 2048.

## Tests

Added comprehensive integration tests in `gpt_test.rs` covering all four return branches:

- `test_find_esp_start_lba_unreadable_header` — LBA 1 read failure → `None`
- `test_find_esp_start_lba_invalid_signature` — zeroed header (no magic) → `None`
- `test_find_esp_start_lba_unreadable_entry_sector` — header OK, entry read fails → `None`
- `test_find_esp_start_lba_valid_gpt_no_esp_entry` — valid GPT, no ESP → `Some(2048)`
- `test_find_esp_start_lba_valid_gpt_with_esp` — valid GPT with ESP → `Some(correct_lba)`

Also added `block::set_active_device` / `block::reset_active_device` test helpers to enable mock injection.