### PR TITLE
fix(io/gpt): distinguish GPT failure modes in fallback_esp (M5)

### DIFF
--- a/main64/kernel/src/drivers/block.rs
+++ b/main64/kernel/src/drivers/block.rs
@@ -218,3 +218,11 @@ pub fn write_sectors(lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError>
 pub fn reset_active_device() {
     *ACTIVE_DEVICE.lock() = None;
 }
+
+/// Install a mock/custom block device as the active device (used for testing
+/// error paths that are impractical to trigger via real hardware, e.g. a
+/// disk-read failure or an absent GPT). Not part of the normal boot path.
+#[doc(hidden)]
+pub fn set_active_device(device: &'static dyn BlockDevice) {
+    *ACTIVE_DEVICE.lock() = Some(device);
+}

--- a/main64/kernel/src/io/gpt.rs
+++ b/main64/kernel/src/io/gpt.rs
@@ -7,23 +7,32 @@ const ESP_TYPE_GUID: [u8; 16] = [
     0x28, 0x73, 0x2A, 0xC1, 0x1F, 0xF8, 0xD2, 0x11, 0xBA, 0x4B, 0x00, 0xA0, 0xC9, 0x3E, 0xC9, 0x3B,
 ];
 
-/// Returns the starting LBA of the EFI System Partition, or None if not found.
+/// Returns the starting LBA of the EFI System Partition, or None if the GPT is
+/// unreadable or absent.
 ///
 /// Reads the GPT header at LBA 1, then iterates through partition entries looking
-/// for the ESP type GUID.
+/// for the ESP type GUID. The `Some(2048)` legacy-default heuristic is used
+/// exclusively for the "valid GPT, no ESP entry declared" case - every other
+/// failure (unreadable header, invalid signature, unreadable entry sector) is
+/// reported faithfully as `None` so the caller can distinguish "no GPT at all"
+/// from "GPT present but genuinely lacks an ESP".
 pub fn find_esp_start_lba() -> Option<u64> {
     let mut header_sector = [0u8; 512];
 
     // Step 1: Read LBA 1 to find the GPT header.
-    // We expect the AHCI driver to succeed in reading this sector.
+    // We expect the block device driver to succeed in reading this sector.
     if block::read_sectors(1, 1, &mut header_sector).is_err() {
-        return fallback_esp();
+        crate::debugln!("GPT: failed to read header sector at LBA 1, GPT unreadable");
+        return None;
     }
 
     // Step 2: Parse the header to get partition array metadata.
     let (entry_lba, num_entries, entry_size) = match parse_gpt_header(&header_sector) {
         Some(info) => info,
-        None => return fallback_esp(),
+        None => {
+            crate::debugln!("GPT: invalid signature or malformed header at LBA 1, no GPT present");
+            return None;
+        }
     };
 
     // Determine how many entries fit in one sector.
@@ -41,7 +50,8 @@ pub fn find_esp_start_lba() -> Option<u64> {
         let lba = (entry_lba + sector_offset as u64) as u32;
 
         if block::read_sectors(lba as u64, 1, &mut entry_sector).is_err() {
-            return fallback_esp();
+            crate::debugln!("GPT: failed to read partition entry sector at LBA {}", lba);
+            return None;
         }
 
         let entries_in_this_sector = core::cmp::min(
@@ -56,7 +66,9 @@ pub fn find_esp_start_lba() -> Option<u64> {
         }
     }
 
-    // None matched.
+    // Valid GPT header parsed and all its entries scanned, but none matched the
+    // ESP type GUID. This is the only case that legitimately falls back to the
+    // legacy default LBA.
     fallback_esp()
 }
 
@@ -101,9 +113,9 @@ pub fn parse_gpt_entries_sector(
     None
 }
 
-/// Fallback if parsing fails or ESP is not found.
+/// Fallback used only when a valid GPT was parsed but no ESP entry was found.
 /// TODO: remove fallback once the primary GPT parsing path is fully stabilized.
 fn fallback_esp() -> Option<u64> {
-    crate::debugln!("ESP not found in GPT, falling back to LBA 2048");
+    crate::debugln!("GPT: valid GPT found but no ESP entry present, falling back to LBA 2048");
     Some(2048)
 }

--- a/main64/kernel/tests/gpt_test.rs
+++ b/main64/kernel/tests/gpt_test.rs
@@ -103,3 +103,158 @@ fn test_parse_gpt_entries_sector_not_found() {
     let result = gpt::parse_gpt_entries_sector(&sector, 4, entry_size);
     assert_eq!(result, None);
 }
+
+// ============================================================================
+// find_esp_start_lba() integration tests
+//
+// These exercise the full function (including its I/O calls) by injecting a
+// mock `BlockDevice` via `block::set_active_device`, so every failure branch
+// documented in issue #17 can be driven deterministically without real disk
+// hardware. See docs/testing.md for how `#[test_case]` tests are structured.
+// ============================================================================
+
+use kaos_kernel::drivers::block::{self, BlockDevice, BlockError};
+use kaos_kernel::sync::spinlock::SpinLock;
+
+/// A `BlockDevice` whose behavior per-LBA is configured at test setup time, so
+/// each test can simulate a specific GPT on-disk layout or I/O failure.
+struct MockBlockDevice {
+    /// Sector returned for reads of LBA 1 (the GPT header). `None` means "fail".
+    lba1_sector: SpinLock<Option<[u8; 512]>>,
+    /// Sector returned for reads of any other LBA (partition entries). `None` means "fail".
+    entry_sector: SpinLock<Option<[u8; 512]>>,
+}
+
+impl MockBlockDevice {
+    const fn new() -> Self {
+        Self {
+            lba1_sector: SpinLock::new(None),
+            entry_sector: SpinLock::new(None),
+        }
+    }
+
+    /// Configure a valid GPT header for LBA 1 with the given partition-array metadata.
+    fn set_valid_header(&self, entry_lba: u64, num_entries: u32, entry_size: u32) {
+        let mut hdr = [0u8; 512];
+        hdr[0..8].copy_from_slice(b"EFI PART");
+        hdr[0x48..0x50].copy_from_slice(&entry_lba.to_le_bytes());
+        hdr[0x50..0x54].copy_from_slice(&num_entries.to_le_bytes());
+        hdr[0x54..0x58].copy_from_slice(&entry_size.to_le_bytes());
+        *self.lba1_sector.lock() = Some(hdr);
+    }
+
+    /// Configure the entry sector to contain a single ESP entry at `start_lba`.
+    fn set_esp_entry(&self, start_lba: u64) {
+        let mut sector = [0u8; 512];
+        sector[0..16].copy_from_slice(&ESP_TYPE_GUID);
+        sector[0x20..0x28].copy_from_slice(&start_lba.to_le_bytes());
+        *self.entry_sector.lock() = Some(sector);
+    }
+
+    /// Configure the entry sector as present but containing no ESP entry.
+    fn set_entry_sector_no_esp(&self) {
+        *self.entry_sector.lock() = Some([0u8; 512]);
+    }
+
+    fn fail_lba1(&self) {
+        *self.lba1_sector.lock() = None;
+    }
+
+    fn fail_entry_sector(&self) {
+        *self.entry_sector.lock() = None;
+    }
+}
+
+impl BlockDevice for MockBlockDevice {
+    fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
+        if count != 1 || buf.len() < 512 {
+            return Err(BlockError::BadBuffer);
+        }
+
+        let slot = if lba == 1 {
+            &self.lba1_sector
+        } else {
+            &self.entry_sector
+        };
+
+        match *slot.lock() {
+            Some(sector) => {
+                buf[..512].copy_from_slice(&sector);
+                Ok(())
+            }
+            None => Err(BlockError::Device),
+        }
+    }
+
+    fn write_sectors(&self, _lba: u64, _count: u32, _buf: &[u8]) -> Result<(), BlockError> {
+        Err(BlockError::Unsupported)
+    }
+}
+
+static MOCK_DEVICE: MockBlockDevice = MockBlockDevice::new();
+
+#[test_case]
+fn test_find_esp_start_lba_header_read_failure_returns_none() {
+    // LBA 1 (the GPT header sector) is unreadable, e.g. no disk / a hardware error.
+    MOCK_DEVICE.fail_lba1();
+    MOCK_DEVICE.fail_entry_sector();
+    block::set_active_device(&MOCK_DEVICE);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_invalid_signature_returns_none() {
+    // LBA 1 reads fine but does not contain a valid "EFI PART" signature -
+    // there is simply no GPT on this disk.
+    let mut bad_header = [0u8; 512];
+    bad_header[0..8].copy_from_slice(b"BAD SIG!");
+    *MOCK_DEVICE.lba1_sector.lock() = Some(bad_header);
+    MOCK_DEVICE.fail_entry_sector();
+    block::set_active_device(&MOCK_DEVICE);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_entry_sector_read_failure_returns_none() {
+    // The header parses correctly, but the partition-entry array itself
+    // cannot be read (e.g. bad sector further into the disk).
+    MOCK_DEVICE.set_valid_header(2, 128, 128);
+    MOCK_DEVICE.fail_entry_sector();
+    block::set_active_device(&MOCK_DEVICE);
+
+    assert_eq!(gpt::find_esp_start_lba(), None);
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_valid_gpt_no_esp_falls_back_to_2048() {
+    // A fully valid, readable GPT - but none of its entries is an ESP. This is
+    // the one case that should still legitimately fall back to LBA 2048.
+    MOCK_DEVICE.set_valid_header(2, 128, 128);
+    MOCK_DEVICE.set_entry_sector_no_esp();
+    block::set_active_device(&MOCK_DEVICE);
+
+    assert_eq!(gpt::find_esp_start_lba(), Some(2048));
+
+    block::reset_active_device();
+}
+
+#[test_case]
+fn test_find_esp_start_lba_valid_gpt_with_esp_returns_its_lba() {
+    // A fully valid GPT whose partition array declares an ESP - the real LBA
+    // from the entry must be returned, not the 2048 heuristic.
+    MOCK_DEVICE.set_valid_header(2, 128, 128);
+    MOCK_DEVICE.set_esp_entry(4096);
+    block::set_active_device(&MOCK_DEVICE);
+
+    assert_eq!(gpt::find_esp_start_lba(), Some(4096));
+
+    block::reset_active_device();
+}


### PR DESCRIPTION
Closes #17

## Problem

`fallback_esp()` previously returned `Some(2048)` for **all** failure cases in `find_esp_start_lba()` — a read error on LBA 1 (the GPT header), an invalid/missing GPT signature, a failed partition-entry sector read, and a genuine "valid GPT but no ESP partition declared". Every failure silently aliased to LBA 2048, making it impossible for the caller (`main.rs`'s `.expect("ESP not found on GPT disk")`) to distinguish "disk unreadable / no GPT at all" from "valid GPT, no ESP, use the legacy default". This risked mounting garbage as a filesystem on a broken/absent-GPT disk instead of panicking loudly.

## Fix

`find_esp_start_lba()` in `main64/kernel/src/io/gpt.rs` now:

- **Header read failure (LBA 1)**: logs `"GPT: failed to read header sector at LBA 1, GPT unreadable"` and returns `None`.
- **Invalid/missing GPT signature**: logs `"GPT: invalid signature or malformed header at LBA 1, no GPT present"` and returns `None`.
- **Partition-entry sector read failure**: logs `"GPT: failed to read partition entry sector at LBA {lba}"` and returns `None`.
- **Valid GPT, no ESP entry found** (the only case that still falls back): logs `"GPT: valid GPT found but no ESP entry present, falling back to LBA 2048"` and returns `Some(2048)`.

`fallback_esp()` is now called only from the final "valid GPT, no ESP" path, with its doc comment and `find_esp_start_lba()`'s doc comment updated to describe all four outcomes explicitly.

**Caller impact**: `main.rs` already does `.expect("ESP not found on GPT disk")` on the `Option`, so `None` correctly propagates as a kernel panic — no caller changes were needed, verified by inspection.

## Tests

Added `block::set_active_device()` in `main64/kernel/src/drivers/block.rs` (mirrors the existing `reset_active_device()` test hook) to inject a mock `BlockDevice` for testing. Added 5 new `#[test_case]` integration tests in `main64/kernel/tests/gpt_test.rs` (alongside the 5 pre-existing parsing tests, kept unchanged):

- `test_find_esp_start_lba_header_read_failure_returns_none`
- `test_find_esp_start_lba_invalid_signature_returns_none`
- `test_find_esp_start_lba_entry_sector_read_failure_returns_none`
- `test_find_esp_start_lba_valid_gpt_no_esp_falls_back_to_2048`
- `test_find_esp_start_lba_valid_gpt_with_esp_returns_its_lba`

## Verification

- `cargo test` (full suite, from `main64/kernel/`): **ALL TESTS PASSED (336/336 test cases across 36 test files)**, including all 10 in `gpt_test` (5 pre-existing + 5 new).
- `cargo clippy` (from `main64/kernel/`, no `--all-targets`): zero warnings.
- `cargo fmt --check` (from `main64/`): no diff.

Diff is scoped to the GPT/block-device subsystem only (`gpt.rs`, `block.rs`, `gpt_test.rs`).