### PR TITLE
M7: fix spurious PIC EOI from yield_now's software timer int

### DIFF
--- a/main64/kernel/src/arch/interrupts/mod.rs
+++ b/main64/kernel/src/arch/interrupts/mod.rs
@@ -34,8 +34,8 @@ pub use types::{
 
 #[allow(unused_imports)]
 pub use pic::{
-    end_of_interrupt, init_periodic_timer, io_wait, is_spurious_irq, mask_pic, pit_divisor_for_hz,
-    remap_pic,
+    end_of_interrupt, init_periodic_timer, io_wait, is_in_service, is_spurious_irq, mask_pic,
+    pit_divisor_for_hz, remap_pic,
 };
 
 #[allow(unused_imports)]
@@ -179,6 +179,20 @@ fn clear_irq_handlers() {
     }
 }
 
+/// Dispatches a hardware IRQ (or an equivalent software `int` on the same
+/// vector) to its registered handler and, as an epilogue, sends the PIC an
+/// End-Of-Interrupt (EOI) — but only when the PIC itself reports the IRQ
+/// line as genuinely in-service.
+///
+/// The EOI is conditional on [`is_in_service`] rather than unconditional on
+/// `vector` alone: a genuine hardware IRQ0..15 assertion latches the
+/// corresponding PIC ISR bit, but a software-triggered `int` on the same
+/// vector (e.g. `scheduler::yield_now`'s `int IRQ0_PIT_TIMER_VECTOR`, used to
+/// reuse the timer's context-switch path without a real PIT edge) never
+/// does. Without this check, dispatching such a software entry would ring a
+/// spurious EOI — acknowledging a service the PIC never recorded — which can
+/// desynchronize the PIC's in-service tracking (e.g. mis-acking a genuinely
+/// in-service interrupt on a later, unrelated EOI). See issue #19.
 pub(crate) fn dispatch_irq(vector: u8, frame: &mut SavedRegisters) -> *mut SavedRegisters {
     // Step 1: map vector to direct IRQ slot (irq0..irq15 => 0..15).
     let Some(irq_idx) = irq_slot_index(vector) else {
@@ -209,7 +223,11 @@ pub(crate) fn dispatch_irq(vector: u8, frame: &mut SavedRegisters) -> *mut Saved
         next_frame = handler(vector, frame);
     }
 
-    if (IRQ_BASE..IRQ_BASE + 16).contains(&vector) {
+    // Step 3: EOI epilogue — only for a vector that genuinely has its PIC
+    // ISR bit set (see doc comment above and `is_in_service`). A software
+    // `int` on this vector never sets that bit, so it naturally skips EOI
+    // here instead of requiring the caller to bypass this dispatch path.
+    if (IRQ_BASE..IRQ_BASE + 16).contains(&vector) && is_in_service(vector - IRQ_BASE) {
         end_of_interrupt(vector - IRQ_BASE);
     }
 

--- a/main64/kernel/src/arch/interrupts/pic.rs
+++ b/main64/kernel/src/arch/interrupts/pic.rs
@@ -2,6 +2,9 @@
 
 use crate::arch::port::PortByte;
 
+#[cfg(debug_assertions)]
+use core::sync::atomic::{AtomicU32, Ordering};
+
 const PIC1_COMMAND: u16 = 0x20;
 const PIC1_DATA: u16 = 0x21;
 const PIC2_COMMAND: u16 = 0xA0;
@@ -85,6 +88,14 @@ pub fn mask_pic() {
 }
 
 pub fn end_of_interrupt(irq: u8) {
+    // Step 1 (debug/test builds only): count every EOI actually issued to the
+    // PIC. Integration tests use this counter to assert that a software
+    // `int` on an IRQ vector (e.g. `scheduler::yield_now`) never reaches this
+    // function unless the PIC genuinely has that line in-service — see
+    // `is_in_service` and its caller in `dispatch_irq` (issue #19).
+    #[cfg(debug_assertions)]
+    EOI_COUNT.fetch_add(1, Ordering::Relaxed);
+
     // SAFETY:
     // - This requires `unsafe` because hardware port I/O is inherently outside Rust's memory-safety guarantees.
     // - EOI commands to PIC ports acknowledge serviced IRQ lines.
@@ -95,6 +106,38 @@ pub fn end_of_interrupt(irq: u8) {
         }
         PortByte::new(PIC1_COMMAND).write(PIC_EOI);
     }
+}
+
+/// Test-only counter of PIC EOI commands actually issued via
+/// [`end_of_interrupt`], across all IRQ lines.
+///
+/// Not gated behind `#[cfg(test)]`: this crate builds with `[lib] test =
+/// false`, and integration tests under `tests/*.rs` link `kaos_kernel` as an
+/// ordinary (non-`--cfg test`) dependency, so `#[cfg(test)]` items in `src/`
+/// are never visible to them. Gated behind `#[cfg(debug_assertions)]`
+/// instead — all test binaries build in the debug profile — matching the
+/// existing `scheduler::TEST_SCHEDULER_ENTER_ASSERT_TS_CLEAR` convention.
+#[cfg(debug_assertions)]
+pub static EOI_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Test-only accessor for [`EOI_COUNT`].
+///
+/// Hidden from public docs; used by integration tests to assert that a given
+/// code path did or did not cause a PIC EOI to be issued.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub fn eoi_count_for_test() -> u32 {
+    EOI_COUNT.load(Ordering::Acquire)
+}
+
+/// Test-only reset of [`EOI_COUNT`] back to zero.
+///
+/// Hidden from public docs; lets each test start from a known baseline
+/// regardless of EOIs issued by earlier tests or kernel init.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub fn reset_eoi_count_for_test() {
+    EOI_COUNT.store(0, Ordering::Release);
 }
 
 /// Computes the PIT divisor for the requested interrupt frequency.
@@ -132,6 +175,49 @@ pub fn init_periodic_timer(hz: u32) {
         cmd.write(PIT_MODE_RATE_GENERATOR);
         data.write((divisor & 0xFF) as u8);
         data.write((divisor >> 8) as u8);
+    }
+}
+
+/// Checks whether the given IRQ line is currently marked in-service on the
+/// 8259 PIC, i.e. the PIC's In-Service Register (ISR) has the corresponding
+/// bit set because a real hardware assertion of that line was acknowledged
+/// by the CPU and no EOI has been sent for it yet.
+///
+/// This is the mechanism that lets [`dispatch_irq`](super::dispatch_irq)
+/// distinguish a genuine hardware IRQ entry from a software-triggered `int`
+/// on the same vector (e.g. `scheduler::yield_now`'s `int
+/// IRQ0_PIT_TIMER_VECTOR`): a software `int` never causes the PIC to latch an
+/// ISR bit, because the PIC itself never saw an edge on that line. Sending an
+/// EOI for such an entry would be spurious — it acknowledges a service the
+/// PIC never recorded, which can desynchronize the PIC's in-service tracking
+/// (e.g. by mis-acking a genuinely in-service interrupt on a later, unrelated
+/// EOI). See issue #19.
+///
+/// `irq` must be in `0..16` (direct IRQ line number, not the IDT vector).
+pub fn is_in_service(irq: u8) -> bool {
+    debug_assert!(
+        irq < 16,
+        "is_in_service: irq must be a valid IRQ line (0..16)"
+    );
+
+    // SAFETY:
+    // - This requires `unsafe` because hardware port I/O is inherently outside Rust's memory-safety guarantees.
+    // - Reading the PIC ISR (In-Service Register) via OCW3 is safe and doesn't mutate PIC state.
+    // - `irq < 8` selects the master PIC's own ISR bit; `irq >= 8` selects the
+    //   slave PIC's ISR bit for `irq - 8` (the slave enumerates IRQ8..15 as
+    //   its own bits 0..7).
+    unsafe {
+        if irq < 8 {
+            let cmd = PortByte::new(PIC1_COMMAND);
+            cmd.write(PIC_ISR_READ);
+            let isr = cmd.read();
+            (isr & (1 << irq)) != 0
+        } else {
+            let cmd = PortByte::new(PIC2_COMMAND);
+            cmd.write(PIC_ISR_READ);
+            let isr = cmd.read();
+            (isr & (1 << (irq - 8))) != 0
+        }
     }
 }
 

--- a/main64/kernel/src/scheduler/roundrobin/mod.rs
+++ b/main64/kernel/src/scheduler/roundrobin/mod.rs
@@ -592,12 +592,20 @@ pub fn exit_current_task() -> ! {
 
 /// Triggers a software timer interrupt to force an immediate reschedule.
 ///
-/// EOI semantics:
-/// - `int IRQ0_PIT_TIMER_VECTOR` is a software interrupt, not a physical PIT edge.
-/// - The shared IRQ dispatcher currently sends PIC EOI for this vector as part
-///   of its normal IRQ epilogue.
-/// - Therefore `timer_irq_handler` must never emit its own EOI; doing so would
-///   duplicate EOI on real hardware IRQ0 entries and obscure this software path.
+/// EOI semantics (issue #19):
+/// - `int IRQ0_PIT_TIMER_VECTOR` is a software interrupt, not a physical PIT edge,
+///   so the 8259 PIC never latches an in-service bit for this entry.
+/// - The shared IRQ dispatcher (`interrupts::dispatch_irq`) only sends a PIC EOI
+///   for a vector when `interrupts::is_in_service` reports the corresponding IRQ
+///   line as genuinely in-service — i.e. the PIC's own ISR register has the bit
+///   set. For this software-triggered entry that bit is never set, so no EOI
+///   reaches the PIC; the previous unconditional-EOI epilogue used to ring a
+///   spurious EOI here, which could desynchronize the PIC's in-service tracking.
+/// - A real hardware IRQ0 tick *does* set the ISR bit before the CPU vectors into
+///   the handler, so `dispatch_irq`'s EOI epilogue still fires exactly as before
+///   for genuine ticks — this fix changes nothing about that path.
+/// - `timer_irq_handler` (the handler registered for this vector) never emits its
+///   own EOI either way; EOI handling stays centralized in `dispatch_irq`.
 pub fn yield_now() {
     // SAFETY:
     // - This requires `unsafe` because inline assembly and privileged CPU instructions are outside Rust's static safety model.

--- a/main64/kernel/tests/interrupts_layout_test.rs
+++ b/main64/kernel/tests/interrupts_layout_test.rs
@@ -12,6 +12,7 @@
 use core::mem::{size_of, MaybeUninit};
 use core::panic::PanicInfo;
 use core::ptr::addr_of;
+use core::sync::atomic::{AtomicU32, Ordering};
 use kaos_kernel::arch::interrupts::{self, SavedRegisters};
 use kaos_kernel::syscall::{self, SyscallId};
 
@@ -377,5 +378,131 @@ fn test_int80_syscall_user_clear_screen_wrapper_resets_cursor() {
     assert!(
         pos == Ok((0, 0)),
         "sys_clear_screen must reset cursor to origin"
+    );
+}
+
+static SOFTWARE_INT_IRQ0_HANDLER_CALLS: AtomicU32 = AtomicU32::new(0);
+
+/// Test-only IRQ0 handler that just counts invocations and leaves the frame
+/// untouched, so dispatch can be observed without pulling in the scheduler.
+fn software_int_irq0_test_handler(_vector: u8, frame: &mut SavedRegisters) -> *mut SavedRegisters {
+    SOFTWARE_INT_IRQ0_HANDLER_CALLS.fetch_add(1, Ordering::Relaxed);
+    frame as *mut SavedRegisters
+}
+
+/// Contract: a software `int` on the timer IRQ vector — the exact mechanism
+/// `scheduler::yield_now` uses to reuse the timer's context-switch path —
+/// must not ring a PIC End-Of-Interrupt, because the 8259 PIC never latches
+/// an in-service bit for a software-triggered entry (issue #19).
+/// Given: The PIC is freshly initialized (remapped + masked to defaults) and
+/// a lightweight test handler is registered for `IRQ0_PIT_TIMER_VECTOR`, so
+/// the dispatcher's full handler-lookup + EOI epilogue runs exactly as it
+/// would for a real `yield_now` call, without depending on the scheduler.
+/// When: `int IRQ0_PIT_TIMER_VECTOR` is executed directly, mirroring
+/// `scheduler::yield_now`'s own inline assembly byte-for-byte.
+/// Then: the registered handler is invoked (proving dispatch actually ran),
+/// the PIC's ISR bit for IRQ0 is not set before or after, and the global EOI
+/// counter does not increase.
+/// Failure Impact: A regression here reintroduces the spurious-EOI bug from
+/// issue #19, which can desynchronize the 8259 PIC's in-service tracking
+/// (e.g. mis-acking a genuinely in-service interrupt on a later EOI).
+#[test_case]
+fn test_software_int_on_irq0_vector_does_not_send_spurious_eoi() {
+    interrupts::init();
+    interrupts::register_irq_handler(
+        interrupts::IRQ0_PIT_TIMER_VECTOR,
+        software_int_irq0_test_handler,
+    );
+    SOFTWARE_INT_IRQ0_HANDLER_CALLS.store(0, Ordering::Release);
+    interrupts::pic::reset_eoi_count_for_test();
+
+    assert!(
+        !interrupts::is_in_service(0),
+        "IRQ0 must not be in-service before a software int is issued"
+    );
+
+    // SAFETY:
+    // - This requires `unsafe` because inline assembly and privileged CPU instructions are outside Rust's static safety model.
+    // - Mirrors `scheduler::yield_now`'s own software `int` on this exact vector.
+    // - `interrupts::init()` above loaded an IDT containing this IRQ gate.
+    // - The test executes in ring 0, so invoking this software interrupt is valid.
+    unsafe {
+        core::arch::asm!(
+            "int {vector}",
+            vector = const interrupts::IRQ0_PIT_TIMER_VECTOR,
+            options(nomem)
+        );
+    }
+
+    assert!(
+        SOFTWARE_INT_IRQ0_HANDLER_CALLS.load(Ordering::Acquire) == 1,
+        "software int must still dispatch to the registered IRQ0 handler"
+    );
+    assert!(
+        !interrupts::is_in_service(0),
+        "IRQ0 must remain not-in-service after a software-triggered entry"
+    );
+    assert!(
+        interrupts::pic::eoi_count_for_test() == 0,
+        "software int on the timer vector must not ring a PIC EOI (issue #19)"
+    );
+}
+
+static HARDWARE_TICK_IRQ0_HANDLER_CALLS: AtomicU32 = AtomicU32::new(0);
+
+/// Test-only IRQ0 handler used by the genuine-hardware-tick regression test
+/// below; counts invocations and leaves the frame untouched.
+fn hardware_tick_irq0_test_handler(_vector: u8, frame: &mut SavedRegisters) -> *mut SavedRegisters {
+    HARDWARE_TICK_IRQ0_HANDLER_CALLS.fetch_add(1, Ordering::Relaxed);
+    frame as *mut SavedRegisters
+}
+
+/// Contract: a genuine hardware IRQ0 (PIT) tick must still be EOI'd exactly
+/// as before this fix — the conditional-EOI change in `dispatch_irq` must
+/// not regress the real timer path that almost every other test relies on.
+/// Given: The PIT is programmed to 250 Hz and interrupts are globally
+/// enabled, with a test handler registered for `IRQ0_PIT_TIMER_VECTOR`.
+/// When: The CPU services several real hardware timer ticks.
+/// Then: The handler runs repeatedly (which is only possible if each tick's
+/// PIC ISR bit is cleared via EOI — the 8259 in fully-nested mode refuses to
+/// re-assert the same line while its ISR bit is still set, so a suppressed
+/// EOI would freeze the handler-call count at 1), and the EOI counter keeps
+/// pace with the handler-call count.
+/// Failure Impact: Indicates the EOI epilogue was made too conservative and
+/// no longer acknowledges genuine hardware IRQs, which would hang the timer
+/// (and therefore the scheduler and most of the test suite).
+#[test_case]
+fn test_genuine_hardware_irq0_tick_still_sends_eoi() {
+    interrupts::init();
+    interrupts::register_irq_handler(
+        interrupts::IRQ0_PIT_TIMER_VECTOR,
+        hardware_tick_irq0_test_handler,
+    );
+    HARDWARE_TICK_IRQ0_HANDLER_CALLS.store(0, Ordering::Release);
+    interrupts::pic::reset_eoi_count_for_test();
+
+    interrupts::init_periodic_timer(250);
+    interrupts::enable();
+
+    let mut observed = false;
+    for _ in 0..5_000_000usize {
+        if HARDWARE_TICK_IRQ0_HANDLER_CALLS.load(Ordering::Acquire) >= 3 {
+            observed = true;
+            break;
+        }
+        core::hint::spin_loop();
+    }
+
+    interrupts::disable();
+
+    let handler_calls = HARDWARE_TICK_IRQ0_HANDLER_CALLS.load(Ordering::Acquire);
+    assert!(
+        observed,
+        "expected several genuine hardware IRQ0 ticks while interrupts were enabled \
+         (a suppressed EOI would have frozen this at 1 tick)"
+    );
+    assert!(
+        interrupts::pic::eoi_count_for_test() >= handler_calls,
+        "every genuine hardware IRQ0 tick must still be EOI'd exactly as before this fix"
     );
 }


### PR DESCRIPTION
Closes #19

## Problem

`scheduler::yield_now()` (`main64/kernel/src/scheduler/roundrobin/mod.rs`) raises a *software* `int IRQ0_PIT_TIMER_VECTOR` purely to reuse the timer's context-switch path through the shared IRQ dispatcher. `dispatch_irq()` (`main64/kernel/src/arch/interrupts/mod.rs`) unconditionally sent a PIC End-Of-Interrupt for any vector in the IRQ range as its epilogue — but a software `int` never causes the 8259 PIC to latch an in-service (ISR) bit for that entry, so this EOI was spurious. Sending EOI for a service the PIC never recorded can desynchronize its in-service tracking (e.g. mis-acking a genuinely in-service interrupt on a later, unrelated EOI).

## Fix (approach b from the issue)

Rather than having `yield_now` hand-roll its own inline-asm trap frame construction / restore to call `on_timer_tick` directly (correct in principle, but intricate, low-confidence surgery on the exact `irq_stub_asm!` frame layout), I made `dispatch_irq`'s EOI epilogue conditional on genuine PIC state:

- Added `pic::is_in_service(irq: u8) -> bool`, which reads the PIC's In-Service Register via OCW3 (the same mechanism `is_spurious_irq` already uses for IRQ7/15) and reports whether that specific IRQ line's ISR bit is actually set.
- `dispatch_irq`'s EOI epilogue now only calls `end_of_interrupt` when `is_in_service(vector - IRQ_BASE)` is true.
- A genuine hardware IRQ0..15 assertion still latches its ISR bit (via the CPU's INTA cycle) before vectoring into the handler, so real ticks are EOI'd exactly as before — no change to that path.
- A software `int` on the same vector (yield_now's mechanism) never sets that bit, so it now naturally skips EOI, without `yield_now` needing to bypass the trap machinery at all.
- Updated the doc comments on `yield_now` and added one above `dispatch_irq` explaining the new conditional-EOI semantics.

## Testing

Since this crate builds with `[lib] test = false` (no `#[cfg(test)]` visibility to integration tests), I added a debug-only EOI counter, `pic::EOI_COUNT` (+ `eoi_count_for_test()` / `reset_eoi_count_for_test()`), gated by `#[cfg(debug_assertions)]` — matching the existing `scheduler::TEST_SCHEDULER_ENTER_ASSERT_TS_CLEAR` / `reset_mounted_fs` test-hook convention in this codebase.

Added two `#[test_case]`s to `kernel/tests/interrupts_layout_test.rs`:

1. `test_software_int_on_irq0_vector_does_not_send_spurious_eoi` — registers a lightweight handler on `IRQ0_PIT_TIMER_VECTOR`, executes `int IRQ0_PIT_TIMER_VECTOR` directly (mirroring `yield_now`'s own inline asm byte-for-byte), and asserts the handler ran but `eoi_count_for_test()` stayed at 0. I verified this test fails without the fix (reverted the `is_in_service` check locally, reran — failed with `"software int on the timer vector must not ring a PIC EOI (issue #19)"` — then restored the fix and reran — passed).
2. `test_genuine_hardware_irq0_tick_still_sends_eoi` — programs the PIT to 250 Hz, enables interrupts, and asserts a real hardware handler is invoked repeatedly (only possible if each tick's ISR bit is actually cleared via EOI — the 8259 in fully-nested mode won't re-assert an IRQ line while its ISR bit is still set, so a suppressed EOI would freeze the call count at 1) and that the EOI counter keeps pace with the handler-call count. This is the regression guard for the real timer path.

## Verification

- `cargo test` (full suite, from `main64/kernel/`): **333/333 test cases pass across all 36 test binaries** — no regressions to the real timer/scheduler path.
- `cargo clippy` (from `main64/kernel/`): zero warnings.
- `cargo fmt --check` (from `main64/`): no diff.