### PR TITLE
Fix M8: wrong error threshold in sys_yield + duplicated syscall decode ladder

### DIFF
--- a/main64/kernel/src/syscall/user.rs
+++ b/main64/kernel/src/syscall/user.rs
@@ -9,7 +9,7 @@
 //!
 //! Design goals:
 //! - keep call sites simple (`Result`-based API where possible),
-//! - keep syscall return decoding explicit at wrapper boundaries,
+//! - keep syscall return decoding centralized in a single [`decode`] helper,
 //! - keep unsafe and ABI details local to wrapper implementations.
 
 use core::arch::asm;
@@ -18,6 +18,34 @@ use super::{
     abi, SysError, SyscallId, SYSCALL_ERR_INVALID_ARG, SYSCALL_ERR_IO, SYSCALL_ERR_OUT_OF_MEMORY,
     SYSCALL_ERR_UNSUPPORTED,
 };
+
+/// Decodes a raw `int 0x80` return value into `Result<u64, SysError>`.
+///
+/// This is the single authoritative mapping from the raw ABI sentinel values
+/// (`SYSCALL_ERR_*`) to [`SysError`] variants, shared by every wrapper in this
+/// module. The four sentinels occupy the contiguous range
+/// `[SYSCALL_ERR_OUT_OF_MEMORY, SYSCALL_ERR_UNSUPPORTED]` (i.e.
+/// `u64::MAX - 3 ..= u64::MAX`) with no gaps, so matching all four explicitly
+/// is exhaustive over the entire error range — no additional `x if x >= ...`
+/// catch-all arm is reachable, and any such arm would be dead code.
+///
+/// # Why this lives here instead of calling `super::decode_result`
+/// User wrappers in this module may execute in ring-3 via aliased code
+/// pages. Calling an external decode helper defined elsewhere in the crate
+/// can jump outside the aliased window and fault in user mode. Marking this
+/// `#[inline(always)]` guarantees the decode logic is compiled directly into
+/// each wrapper's own machine code rather than emitted as a real call.
+#[inline(always)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub const fn decode(raw: u64) -> Result<u64, SysError> {
+    match raw {
+        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
+        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
+        SYSCALL_ERR_IO => Err(SysError::IoError),
+        SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
+        value => Ok(value),
+    }
+}
 
 /// Normalizes a raw input byte for one-shot console echo.
 ///
@@ -49,17 +77,7 @@ pub fn sys_yield() -> Result<(), SysError> {
         abi::syscall0(SyscallId::Yield as u64)
     };
 
-    // Keep decoding local in this module:
-    // - User wrappers may execute in ring-3 via aliased code pages.
-    // - Calling an external decode helper can jump to an unmapped
-    //   higher-half kernel text page and fault in user mode.
-    // - This explicit match keeps the wrapper path self-contained.
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Writes `len` bytes from `ptr` to the kernel debug serial output (COM1).
@@ -86,15 +104,7 @@ pub unsafe fn sys_write_serial(ptr: *const u8, len: usize) -> Result<usize, SysE
         abi::syscall2(SyscallId::WriteSerial as u64, ptr as u64, len as u64)
     };
 
-    // Keep decoding local for the same reason as `sys_yield`: avoid extra
-    // helper calls outside the user-aliased wrapper path.
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        written => Ok(written as usize),
-    }
+    decode(raw_value).map(|written| written as usize)
 }
 
 /// Writes `len` bytes from `ptr` to the VGA text console.
@@ -121,13 +131,7 @@ pub unsafe fn sys_write_console(ptr: *const u8, len: usize) -> Result<usize, Sys
         abi::syscall2(SyscallId::WriteConsole as u64, ptr as u64, len as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        written => Ok(written as usize),
-    }
+    decode(raw_value).map(|written| written as usize)
 }
 
 /// Reads a single character from the keyboard (blocking).
@@ -163,13 +167,7 @@ pub fn sys_getchar() -> Result<u8, SysError> {
         abi::syscall0(SyscallId::GetChar as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        ch => Ok(ch as u8),
-    }
+    decode(raw_value).map(|ch| ch as u8)
 }
 
 /// Returns the current VGA cursor position as `(row, col)`.
@@ -184,13 +182,7 @@ pub fn sys_get_cursor() -> Result<(usize, usize), SysError> {
         abi::syscall0(SyscallId::GetCursor as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        packed => Ok(((packed >> 32) as usize, (packed & 0xFFFF_FFFF) as usize)),
-    }
+    decode(raw_value).map(|packed| ((packed >> 32) as usize, (packed & 0xFFFF_FFFF) as usize))
 }
 
 /// Sets the VGA cursor position.
@@ -207,13 +199,7 @@ pub fn sys_set_cursor(row: usize, col: usize) -> Result<(), SysError> {
         abi::syscall2(SyscallId::SetCursor as u64, row as u64, col as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Clears the VGA text screen and resets cursor to `(0, 0)`.
@@ -228,13 +214,7 @@ pub fn sys_clear_screen() -> Result<(), SysError> {
         abi::syscall0(SyscallId::ClearScreen as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        x if x >= SYSCALL_ERR_IO => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Terminates the current task.
@@ -302,8 +282,6 @@ pub fn user_readline(buf: &mut [u8]) -> Result<usize, SysError> {
 
     loop {
         // Block until a character is available.
-        // Keep decoding local to avoid pulling additional Result<T, E> helper
-        // pages into the ring-3 alias mapping.
         let get_char_raw = unsafe {
             // SAFETY:
             // - This requires `unsafe` because syscall entry executes raw ABI-level interrupt machinery.
@@ -311,19 +289,7 @@ pub fn user_readline(buf: &mut [u8]) -> Result<usize, SysError> {
             // - GetChar has no memory arguments.
             abi::syscall0(SyscallId::GetChar as u64)
         };
-        if get_char_raw == SYSCALL_ERR_UNSUPPORTED {
-            return Err(SysError::UnsupportedSyscall);
-        }
-        if get_char_raw == SYSCALL_ERR_INVALID_ARG {
-            return Err(SysError::InvalidArgument);
-        }
-        if get_char_raw == SYSCALL_ERR_IO {
-            return Err(SysError::IoError);
-        }
-        if get_char_raw >= SYSCALL_ERR_IO {
-            return Err(SysError::Unknown(get_char_raw));
-        }
-        let ch = get_char_raw as u8;
+        let ch = decode(get_char_raw)? as u8;
 
         match ch {
             // Enter key - finish reading
@@ -340,18 +306,7 @@ pub fn user_readline(buf: &mut [u8]) -> Result<usize, SysError> {
                         1,
                     )
                 };
-                if raw == SYSCALL_ERR_UNSUPPORTED {
-                    return Err(SysError::UnsupportedSyscall);
-                }
-                if raw == SYSCALL_ERR_INVALID_ARG {
-                    return Err(SysError::InvalidArgument);
-                }
-                if raw == SYSCALL_ERR_IO {
-                    return Err(SysError::IoError);
-                }
-                if raw >= SYSCALL_ERR_IO {
-                    return Err(SysError::Unknown(raw));
-                }
+                decode(raw)?;
                 break;
             }
 
@@ -371,18 +326,7 @@ pub fn user_readline(buf: &mut [u8]) -> Result<usize, SysError> {
                             1,
                         )
                     };
-                    if raw == SYSCALL_ERR_UNSUPPORTED {
-                        return Err(SysError::UnsupportedSyscall);
-                    }
-                    if raw == SYSCALL_ERR_INVALID_ARG {
-                        return Err(SysError::InvalidArgument);
-                    }
-                    if raw == SYSCALL_ERR_IO {
-                        return Err(SysError::IoError);
-                    }
-                    if raw >= SYSCALL_ERR_IO {
-                        return Err(SysError::Unknown(raw));
-                    }
+                    decode(raw)?;
                 }
             }
 
@@ -398,18 +342,7 @@ pub fn user_readline(buf: &mut [u8]) -> Result<usize, SysError> {
                         // - `ch` is a valid stack byte and readable for 1 byte.
                         abi::syscall2(SyscallId::WriteConsole as u64, (&ch as *const u8) as u64, 1)
                     };
-                    if raw == SYSCALL_ERR_UNSUPPORTED {
-                        return Err(SysError::UnsupportedSyscall);
-                    }
-                    if raw == SYSCALL_ERR_INVALID_ARG {
-                        return Err(SysError::InvalidArgument);
-                    }
-                    if raw == SYSCALL_ERR_IO {
-                        return Err(SysError::IoError);
-                    }
-                    if raw >= SYSCALL_ERR_IO {
-                        return Err(SysError::Unknown(raw));
-                    }
+                    decode(raw)?;
                 }
             }
         }
@@ -450,14 +383,7 @@ pub unsafe fn sys_mmap(addr: u64, length: usize) -> Result<*mut u8, SysError> {
     // Valid user heap addresses (0x0000_7000_1000_0000...) are safely below the
     // error sentinel range (u64::MAX - 3 .. u64::MAX) so there is no ambiguity
     // between a successful pointer return and an error code.
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        SYSCALL_ERR_IO => Err(SysError::IoError),
-        SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
-        x if x >= SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::Unknown(x)),
-        ptr => Ok(ptr as *mut u8),
-    }
+    decode(raw_value).map(|ptr| ptr as *mut u8)
 }
 
 /// Queries the total count of discovered PCI devices.
@@ -471,12 +397,7 @@ pub fn sys_get_pci_device_count() -> Result<usize, SysError> {
         abi::syscall0(SyscallId::GetPciDeviceCount as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        count => Ok(count as usize),
-    }
+    decode(raw_value).map(|count| count as usize)
 }
 
 /// Copies the PCI device metadata at `index` into the user-provided structure.
@@ -497,12 +418,7 @@ pub unsafe fn sys_get_pci_device(
         abi::syscall2(SyscallId::GetPciDevice as u64, index as u64, out as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Queries the total count of BIOS memory map entries.
@@ -516,12 +432,7 @@ pub fn sys_get_bios_memory_map_entry_count() -> Result<usize, SysError> {
         abi::syscall0(SyscallId::GetBiosMemoryMapEntryCount as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        count => Ok(count as usize),
-    }
+    decode(raw_value).map(|count| count as usize)
 }
 
 /// Copies the BIOS memory map entry metadata at `index` into the user-provided structure.
@@ -546,12 +457,7 @@ pub unsafe fn sys_get_bios_memory_map_entry(
         )
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Copies the current high-precision calendar date and time into the user-provided structure.
@@ -569,12 +475,7 @@ pub unsafe fn sys_get_time(out: *mut super::types::UserDateTime) -> Result<(), S
         abi::syscall1(SyscallId::GetTime as u64, out as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        _ => Ok(()),
-    }
+    decode(raw_value).map(|_| ())
 }
 
 /// Non-blocking check for a keyboard key event.
@@ -590,10 +491,5 @@ pub fn sys_poll_key() -> Result<u8, SysError> {
         abi::syscall0(SyscallId::PollKey as u64)
     };
 
-    match raw_value {
-        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
-        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
-        x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x)),
-        byte => Ok(byte as u8),
-    }
+    decode(raw_value).map(|byte| byte as u8)
 }

--- a/main64/kernel/tests/syscall_dispatch_test.rs
+++ b/main64/kernel/tests/syscall_dispatch_test.rs
@@ -465,6 +465,97 @@ fn test_echo_input_normalization_preserves_regular_bytes() {
     );
 }
 
+/// Contract: `syscall::user::decode` maps every raw ABI error sentinel to its
+/// corresponding `SysError` variant.
+/// Given: The four `SYSCALL_ERR_*` sentinel values defined by the ABI.
+/// When: Each sentinel is passed to `syscall::user::decode`.
+/// Then: Each must decode to its dedicated `SysError` variant, not `Unknown`.
+/// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
+#[test_case]
+fn test_user_decode_maps_known_error_sentinels() {
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_UNSUPPORTED)
+            == Err(SysError::UnsupportedSyscall),
+        "SYSCALL_ERR_UNSUPPORTED must decode to SysError::UnsupportedSyscall"
+    );
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_INVALID_ARG) == Err(SysError::InvalidArgument),
+        "SYSCALL_ERR_INVALID_ARG must decode to SysError::InvalidArgument"
+    );
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_IO) == Err(SysError::IoError),
+        "SYSCALL_ERR_IO must decode to SysError::IoError"
+    );
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_OUT_OF_MEMORY) == Err(SysError::OutOfMemory),
+        "SYSCALL_ERR_OUT_OF_MEMORY must decode to SysError::OutOfMemory"
+    );
+}
+
+/// Contract: `syscall::user::decode` never misclassifies an IO or
+/// OutOfMemory sentinel as success.
+///
+/// This is the exact regression the M8 fix (issue #20) targets: the old
+/// `sys_yield` decoder used the threshold `x if x >= SYSCALL_ERR_INVALID_ARG`,
+/// which is numerically *higher* than `SYSCALL_ERR_IO` and
+/// `SYSCALL_ERR_OUT_OF_MEMORY`. Both sentinels therefore fell through to the
+/// wrapper's default `_ => Ok(())` arm and were silently treated as success.
+/// Given: The `SYSCALL_ERR_IO` and `SYSCALL_ERR_OUT_OF_MEMORY` sentinels.
+/// When: Each is passed to `syscall::user::decode`.
+/// Then: Both must decode to `Err(...)`, never `Ok(...)`.
+/// Failure Impact: A regression here means a real IO or allocator failure at
+/// the syscall boundary is silently swallowed and treated as success by
+/// every wrapper in `syscall::user`.
+#[test_case]
+fn test_user_decode_does_not_misclassify_io_or_oom_as_success() {
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_IO).is_err(),
+        "SYSCALL_ERR_IO must never decode to Ok(_) (old sys_yield threshold bug)"
+    );
+    assert!(
+        syscall::user::decode(syscall::SYSCALL_ERR_OUT_OF_MEMORY).is_err(),
+        "SYSCALL_ERR_OUT_OF_MEMORY must never decode to Ok(_) (old sys_yield threshold bug)"
+    );
+}
+
+/// Contract: `syscall::user::decode` keeps values below the error sentinel
+/// range as success, including the boundary value directly adjacent to the
+/// lowest sentinel (`SYSCALL_ERR_OUT_OF_MEMORY`).
+/// Given: The value immediately below `SYSCALL_ERR_OUT_OF_MEMORY`.
+/// When: It is passed to `syscall::user::decode`.
+/// Then: It must decode to `Ok` with the value unchanged.
+/// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
+#[test_case]
+fn test_user_decode_accepts_value_just_below_error_sentinels() {
+    let raw = syscall::SYSCALL_ERR_OUT_OF_MEMORY - 1;
+    assert!(
+        syscall::user::decode(raw) == Ok(raw),
+        "value directly below the lowest error sentinel must remain a successful return"
+    );
+}
+
+/// Contract: `syscall::user::decode` passes through ordinary successful
+/// return values unchanged, including zero and small positive values.
+/// Given: A representative set of non-sentinel `u64` values.
+/// When: Each is passed to `syscall::user::decode`.
+/// Then: Each must decode to `Ok` with the value unchanged.
+/// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
+#[test_case]
+fn test_user_decode_passes_success_values_unchanged() {
+    assert!(
+        syscall::user::decode(0) == Ok(0),
+        "zero must remain a successful return"
+    );
+    assert!(
+        syscall::user::decode(17) == Ok(17),
+        "positive result must remain unchanged"
+    );
+    assert!(
+        syscall::user::decode(u64::MAX / 2) == Ok(u64::MAX / 2),
+        "large but non-sentinel values must remain a successful return"
+    );
+}
+
 /// Contract: write_serial rejects null pointer when len > 0.
 /// Given: The subsystem is initialized with the explicit preconditions in this test body, including any literal addresses, vectors, sizes, flags, and constants used below.
 /// When: The exact operation sequence in this function is executed against that state.


### PR DESCRIPTION
Closes #20

## What was wrong

`main64/kernel/src/syscall/user.rs` duplicated the raw `int 0x80` return-value
decode ladder (matching `SYSCALL_ERR_INVALID_ARG`/`IO`/`OUT_OF_MEMORY`/`UNSUPPORTED`
sentinels against `SysError`) in roughly 16 wrappers.

The sentinels are defined as consecutive integers:
- `SYSCALL_ERR_UNSUPPORTED = u64::MAX`
- `SYSCALL_ERR_INVALID_ARG = u64::MAX - 1`
- `SYSCALL_ERR_IO = u64::MAX - 2`
- `SYSCALL_ERR_OUT_OF_MEMORY = u64::MAX - 3`

`sys_yield()`'s decode ladder used the catch-all guard
`x if x >= SYSCALL_ERR_INVALID_ARG => Err(SysError::Unknown(x))`. Since
`SYSCALL_ERR_INVALID_ARG` is numerically *higher* than both `SYSCALL_ERR_IO`
and `SYSCALL_ERR_OUT_OF_MEMORY`, that threshold was too high: raw return
values equal to the IO or OOM sentinel don't match any arm and fall through
to `sys_yield`'s default `_ => Ok(())` arm, silently treating a real IO or
out-of-memory failure as success. The same class of bug (wrong/too-high
threshold, silently dropping IO/OOM sentinels into the success arm) was also
present in `sys_get_pci_device_count`, `sys_get_pci_device`,
`sys_get_bios_memory_map_entry_count`, `sys_get_bios_memory_map_entry`,
`sys_get_time`, and `sys_poll_key` (all used the `INVALID_ARG` threshold), and
`sys_write_serial`, `sys_write_console`, `sys_getchar`, `sys_get_cursor`,
`sys_set_cursor`, and `sys_clear_screen` (all used the `IO` threshold instead
of the lowest sentinel, `OUT_OF_MEMORY`, so they silently dropped only the OOM
sentinel into success).

Additionally, in every ladder that named all values from a given threshold
upward explicitly (e.g. `sys_yield`'s two exact arms for `UNSUPPORTED` and
`INVALID_ARG`), the trailing `x if x >= ... => Err(SysError::Unknown(x))` arm
was dead code: it was fully shadowed by the exact-match arms above it, since
those already covered every value in the guard's range.

## The fix

Introduced a single shared function in `user.rs`:

```rust
#[inline(always)]
pub const fn decode(raw: u64) -> Result<u64, SysError> {
    match raw {
        SYSCALL_ERR_UNSUPPORTED => Err(SysError::UnsupportedSyscall),
        SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
        SYSCALL_ERR_IO => Err(SysError::IoError),
        SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
        value => Ok(value),
    }
}
```

Because the four sentinels are contiguous (`u64::MAX-3..=u64::MAX`) with no
gaps, matching all four exactly is already exhaustive over the entire error
range — there is no reachable "unknown-but-in-range" value, so the dead
`x if x >= ...` catch-all guard is dropped entirely rather than duplicated.

Every wrapper in `user.rs` — `sys_yield`, `sys_write_serial`,
`sys_write_console`, `sys_getchar`, `sys_get_cursor`, `sys_set_cursor`,
`sys_clear_screen`, `sys_mmap`, `sys_get_pci_device_count`,
`sys_get_pci_device`, `sys_get_bios_memory_map_entry_count`,
`sys_get_bios_memory_map_entry`, `sys_get_time`, `sys_poll_key`, and the four
manual if-ladders inside `user_readline` — now call `decode()` instead of
repeating the match.

`decode` stays local to `user.rs` (rather than reusing
`syscall::decode_result` in `types.rs`, which already existed with the
correct logic and is used by the separate `lib_kaos` user-space crate)
because these wrappers may run in ring-3 via an aliased code window per the
module's existing design notes; `#[inline(always)]` on a `const fn`
guarantees the decode logic is compiled directly into each wrapper's own
machine code rather than emitted as a real call that could jump outside the
aliased page. `types.rs::decode_result` and its existing tests are
untouched.

## Testing

Added four `#[test_case]`s to `main64/kernel/tests/syscall_dispatch_test.rs`
(the existing integration test file most relevant to syscall decode logic):

- `test_user_decode_maps_known_error_sentinels` — all four sentinels decode
  to their dedicated `SysError` variant.
- `test_user_decode_does_not_misclassify_io_or_oom_as_success` — the exact
  regression this fix targets: `SYSCALL_ERR_IO` and `SYSCALL_ERR_OUT_OF_MEMORY`
  must never decode to `Ok(_)`. This test fails against the old `sys_yield`
  threshold logic and passes now.
- `test_user_decode_accepts_value_just_below_error_sentinels` — boundary
  value directly below the lowest sentinel remains success.
- `test_user_decode_passes_success_values_unchanged` — ordinary values (0,
  17, `u64::MAX / 2`) pass through unchanged.

### Verification (all green)
- `cargo test` from `main64/kernel/` — full integration suite, **36 test
  binaries / 335 test cases, all passed**, including `syscall_dispatch_test`
  (68/68, was 64 before + 4 new), `process_contract_test` (20/20) and
  `user_mode_iretq_smoke_test` (1/1) which exercise these wrappers under real
  ring-3 execution.
- `cargo clippy` from `main64/kernel/` — zero warnings.
- `cargo fmt --check` from `main64/` — no diff.

Diff is scoped to `main64/kernel/src/syscall/user.rs` and
`main64/kernel/tests/syscall_dispatch_test.rs` only.