### PR TITLE
Fix #16: apply console VRAM flush outside GLOBAL_CONSOLE's interrupt-disabling lock

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -59,6 +59,9 @@ name = "scheduler_not_initialized_test"
 name = "screen_test"
 
 [[test]]
+name = "console_flush_lock_test"
+
+[[test]]
 name = "keyboard_e2e_test"
 
 [[test]]

--- a/main64/kernel/src/console/dispatch.rs
+++ b/main64/kernel/src/console/dispatch.rs
@@ -3,6 +3,7 @@
 //! Provides the `ConsoleImpl` enum wrapper that delegates all `KernelConsole`
 //! operations to the currently active backend.
 
+use super::interface::PendingFlush;
 use super::{FramebufferConsole, KernelConsole, VgaConsole};
 use crate::drivers::screen::Color;
 
@@ -169,6 +170,17 @@ impl KernelConsole for ConsoleImpl {
         match self {
             ConsoleImpl::Vga(inner) => inner.enable_blink_mode(),
             ConsoleImpl::Framebuffer(inner) => inner.enable_blink_mode(),
+        }
+    }
+
+    fn take_pending_flush(&mut self) -> Option<PendingFlush> {
+        // Extract any deferred VRAM upload queued by the active variant. `Vga`
+        // has no backbuffer/dirty-tracking concept and relies on the trait's
+        // default (`None`); `Framebuffer` overrides it to snapshot its dirty
+        // region (see issue #16).
+        match self {
+            ConsoleImpl::Vga(inner) => inner.take_pending_flush(),
+            ConsoleImpl::Framebuffer(inner) => inner.take_pending_flush(),
         }
     }
 }

--- a/main64/kernel/src/console/framebuffer.rs
+++ b/main64/kernel/src/console/framebuffer.rs
@@ -3,6 +3,7 @@
 //! Implements a console backend that renders text into the graphics
 //! framebuffer using a static 8x16 bitmap font.
 
+use super::interface::PendingFlush;
 use super::KernelConsole;
 use crate::boot_info::PixelFormat;
 use crate::drivers::screen::Color;
@@ -34,6 +35,12 @@ pub struct FramebufferConsole {
 
     /// RAM Backbuffer for pixel data to avoid slow VRAM reads and partial writes.
     backbuffer: alloc::vec::Vec<u32>,
+    /// Scratch buffer used to snapshot the dirty region out of `backbuffer`
+    /// while `GLOBAL_CONSOLE`'s lock is held (see `take_flush_job`). Allocated
+    /// once, sized identically to `backbuffer`, and never reallocated
+    /// afterward, so pointers into it stay valid for a `PendingFlush` that
+    /// outlives the lock that produced it (issue #16).
+    flush_scratch: alloc::vec::Vec<u32>,
     /// Minimum y-coordinate (scanline) that has been modified since last VRAM flush.
     dirty_y_min: u32,
     /// Maximum y-coordinate (scanline) that has been modified since last VRAM flush.
@@ -78,8 +85,10 @@ impl FramebufferConsole {
         let cells = alloc::vec![0x0720; cols * rows];
 
         let mut backbuffer = alloc::vec::Vec::new();
+        let mut flush_scratch = alloc::vec::Vec::new();
         if bb_size > 0 {
             backbuffer.resize(bb_size, 0);
+            flush_scratch.resize(bb_size, 0);
         }
 
         Self {
@@ -93,6 +102,7 @@ impl FramebufferConsole {
             cursor_enabled: true,
             fb_info,
             backbuffer,
+            flush_scratch,
             dirty_y_min: u32::MAX,
             dirty_y_max: 0,
             deferred_redraw: false,
@@ -275,43 +285,81 @@ impl FramebufferConsole {
         }
     }
 
-    /// Flushes dirty scanlines from the backbuffer to the physical VRAM.
-    fn flush_to_vram(&mut self) {
-        if self.dirty_y_min <= self.dirty_y_max {
-            if let Some(fb) = self.fb_info {
-                let fb_ptr = fb.base_address as *mut u32;
-                let min_y = self.dirty_y_min;
-                let max_y = self.dirty_y_max.min(fb.height.saturating_sub(1));
-
-                if min_y <= max_y {
-                    let start_offset = (min_y * fb.pixels_per_scanline) as usize;
-                    let lines_to_copy = max_y - min_y + 1;
-                    let pixels_to_copy = (lines_to_copy * fb.pixels_per_scanline) as usize;
-
-                    // SAFETY:
-                    // - `backbuffer` is large enough for all scanlines.
-                    // - `fb_ptr` is the physical identity-mapped framebuffer memory.
-                    // - The copy is bounded by height.
-                    unsafe {
-                        core::ptr::copy_nonoverlapping(
-                            self.backbuffer.as_ptr().add(start_offset),
-                            fb_ptr.add(start_offset),
-                            pixels_to_copy,
-                        );
-                    }
-                }
-            }
-            self.dirty_y_min = u32::MAX;
-            self.dirty_y_max = 0;
+    /// Snapshots the dirty scanline range from the RAM backbuffer into the
+    /// (never-reallocated) `flush_scratch` buffer and resets dirty tracking.
+    ///
+    /// This is a fast RAM-to-RAM `memcpy`, cheap enough to run while still
+    /// holding `GLOBAL_CONSOLE`'s lock. The returned [`PendingFlush`]
+    /// describes the actual (slow, MMIO-bound) VRAM upload, which
+    /// `with_console` performs only after releasing the lock — see issue #16
+    /// ("Console holds an interrupt-disabling lock across full-screen VRAM
+    /// flush").
+    fn take_flush_job(&mut self) -> Option<PendingFlush> {
+        if self.dirty_y_min > self.dirty_y_max {
+            return None;
         }
+
+        let fb = self.fb_info?;
+        let min_y = self.dirty_y_min;
+        let max_y = self.dirty_y_max.min(fb.height.saturating_sub(1));
+
+        // Reset dirty tracking now: any writes that happen after this point
+        // (e.g. from a nested interrupt handler) must mark a fresh dirty
+        // range for the *next* flush job rather than being silently dropped.
+        self.dirty_y_min = u32::MAX;
+        self.dirty_y_max = 0;
+
+        if min_y > max_y {
+            return None;
+        }
+
+        let start_offset = (min_y * fb.pixels_per_scanline) as usize;
+        let lines_to_copy = max_y - min_y + 1;
+        let pixels_to_copy = (lines_to_copy * fb.pixels_per_scanline) as usize;
+
+        // SAFETY:
+        // - `backbuffer` and `flush_scratch` are both sized to
+        //   `pixels_per_scanline * height` (see `new`) and never reallocated
+        //   afterward.
+        // - `min_y`/`max_y` are bounded by `fb.height`, so `start_offset +
+        //   pixels_to_copy` stays within both buffers.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                self.backbuffer.as_ptr().add(start_offset),
+                self.flush_scratch.as_mut_ptr().add(start_offset),
+                pixels_to_copy,
+            );
+        }
+
+        let fb_ptr = fb.base_address as *mut u32;
+
+        // SAFETY:
+        // - `src` points into `flush_scratch`, which is heap-allocated once in
+        //   `new()` and never reallocated/moved for the lifetime of this
+        //   console, so the pointer stays valid after this function returns
+        //   (i.e. after `GLOBAL_CONSOLE`'s lock has been released).
+        // - `dst` points into the physical linear framebuffer at an offset
+        //   bounded by `fb.height`/`fb.pixels_per_scanline`, matching the
+        //   same bounds check used for the snapshot copy above.
+        let flush = unsafe {
+            PendingFlush::new(
+                self.flush_scratch.as_ptr().add(start_offset),
+                fb_ptr.add(start_offset),
+                pixels_to_copy,
+            )
+        };
+
+        Some(flush)
     }
 
-    /// Handles deferred or explicit redraw synchronization.
+    /// Resets the deferred-redraw marker.
+    ///
+    /// Note: this no longer performs the VRAM upload itself — see
+    /// `take_flush_job`/`KernelConsole::take_pending_flush`, which let
+    /// `with_console` apply the (potentially large) upload only after
+    /// releasing the console lock (issue #16).
     fn flush_redraw(&mut self) {
-        if self.deferred_redraw {
-            self.deferred_redraw = false;
-        }
-        self.flush_to_vram();
+        self.deferred_redraw = false;
     }
 
     /// Shifts character cells upward when the cursor advances past the last visible row.
@@ -600,6 +648,10 @@ impl KernelConsole for FramebufferConsole {
 
     fn enable_blink_mode(&mut self) {
         // No-op for framebuffer.
+    }
+
+    fn take_pending_flush(&mut self) -> Option<PendingFlush> {
+        self.take_flush_job()
     }
 }
 

--- a/main64/kernel/src/console/interface.rs
+++ b/main64/kernel/src/console/interface.rs
@@ -7,9 +7,11 @@
 #![allow(clippy::too_many_arguments)]
 
 use super::{ConsoleImpl, FramebufferConsole, VgaConsole};
+use crate::arch::interrupts;
 use crate::boot_info::VideoModeType;
 use crate::drivers::screen::Color;
 use crate::sync::spinlock::SpinLock;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 /// Unified trait for kernel console outputs.
 ///
@@ -87,6 +89,116 @@ pub trait KernelConsole: core::fmt::Write + Send {
 
     /// Restores default VGA text mode blinking behavior.
     fn enable_blink_mode(&mut self);
+
+    /// Extracts any VRAM upload queued by preceding drawing operations on this
+    /// console, if the backend buffers pixel data in RAM instead of writing
+    /// straight to hardware on every call (see `FramebufferConsole`).
+    ///
+    /// This step is intentionally kept cheap: implementors only snapshot the
+    /// dirty pixel range into a private scratch buffer (a RAM-to-RAM `memcpy`)
+    /// and reset their dirty tracking, so it remains safe to run while still
+    /// holding `GLOBAL_CONSOLE`'s interrupt-disabling lock. The returned
+    /// descriptor carries everything needed to perform the actual (slow,
+    /// MMIO-bound) VRAM write, which `with_console` performs via
+    /// [`PendingFlush::apply`] *after* releasing the lock. This is the fix for
+    /// issue #16 ("Console holds an interrupt-disabling lock across
+    /// full-screen VRAM flush"): the expensive blit no longer happens with
+    /// interrupts disabled.
+    ///
+    /// Backends without a RAM backbuffer (e.g. `VgaConsole`, which writes
+    /// each character straight to VGA text-mode MMIO as it goes and therefore
+    /// has nothing to defer) rely on this default no-op implementation.
+    fn take_pending_flush(&mut self) -> Option<PendingFlush> {
+        None
+    }
+}
+
+/// A deferred VRAM upload captured while `GLOBAL_CONSOLE`'s lock was held.
+///
+/// Produced by [`KernelConsole::take_pending_flush`] and applied by
+/// `with_console` after the lock guard (and the interrupt-disabled window
+/// that comes with holding it) has already been dropped. This keeps the
+/// slow, MMIO-bound `copy_nonoverlapping` used to upload pixels to the
+/// physical framebuffer out of the console's interrupt-masking critical
+/// section — see issue #16.
+///
+/// # Accepted trade-off
+///
+/// Because the actual blit runs without the console lock held, a nested
+/// caller (e.g. an interrupt handler that also prints to the console, see
+/// `arch::interrupts::handlers`) could in principle start a *new* flush job
+/// whose snapshot phase overlaps the scratch buffer this job is still
+/// reading from. On this single-core kernel this can only manifest as a
+/// visually inconsistent frame — never a use-after-free or an out-of-bounds
+/// access, since the backing buffers are never reallocated for the lifetime
+/// of the console backend. This is explicitly the trade-off called out by
+/// issue #16 ("copy the dirty region out under the lock, then perform the
+/// VRAM blit after releasing the lock") and is preferable to disabling
+/// interrupts across a full-screen MMIO copy.
+pub struct PendingFlush {
+    src: *const u32,
+    dst: *mut u32,
+    len: usize,
+}
+
+impl PendingFlush {
+    /// Builds a new pending flush descriptor.
+    ///
+    /// Only backends that override `take_pending_flush` (currently just
+    /// `FramebufferConsole`) construct this. Keeping the fields private
+    /// keeps the safety invariants documented on [`PendingFlush`] enforceable
+    /// from a single place.
+    pub(crate) fn new(src: *const u32, dst: *mut u32, len: usize) -> Self {
+        Self { src, dst, len }
+    }
+
+    /// Performs the deferred VRAM write.
+    ///
+    /// Must be called *without* holding `GLOBAL_CONSOLE`'s lock (see
+    /// `with_console`), so the slow MMIO copy does not happen with
+    /// interrupts disabled.
+    fn apply(self) {
+        if self.len == 0 {
+            return;
+        }
+
+        // Test-only introspection (see `last_flush_ran_with_interrupts_enabled`):
+        // record whether interrupts were enabled right before performing the
+        // (potentially large) VRAM copy below. Cheap enough to always record.
+        LAST_FLUSH_INTERRUPTS_ENABLED.store(interrupts::are_enabled(), Ordering::Relaxed);
+
+        // SAFETY:
+        // - `src`/`dst`/`len` were validated against in-bounds, non-overlapping
+        //   buffers at capture time by the backend that built this descriptor
+        //   (see `FramebufferConsole::take_flush_job`).
+        // - The scratch buffer backing `src` is heap-allocated once and never
+        //   reallocated/moved for the lifetime of the console backend, and the
+        //   physical framebuffer backing `dst` is fixed for the boot session,
+        //   so both pointers remain valid even though the console lock that
+        //   produced them has since been released.
+        unsafe {
+            core::ptr::copy_nonoverlapping(self.src, self.dst, self.len);
+        }
+    }
+}
+
+/// Test-only introspection flag recording whether interrupts were enabled at
+/// the moment the most recent deferred VRAM flush (see [`PendingFlush::apply`])
+/// actually ran. Read via [`last_flush_ran_with_interrupts_enabled`].
+///
+/// Used by integration tests to verify issue #16's fix: the (potentially
+/// full-screen) VRAM `copy_nonoverlapping` must happen outside of
+/// `GLOBAL_CONSOLE`'s interrupt-disabling critical section.
+static LAST_FLUSH_INTERRUPTS_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Test-only accessor for [`LAST_FLUSH_INTERRUPTS_ENABLED`].
+///
+/// Follows the existing `#[doc(hidden)] pub` convention used elsewhere in the
+/// kernel for test-only introspection hooks (e.g. `block::reset_active_device`,
+/// `scheduler::reset_initialization_for_test`).
+#[doc(hidden)]
+pub fn last_flush_ran_with_interrupts_enabled() -> bool {
+    LAST_FLUSH_INTERRUPTS_ENABLED.load(Ordering::Relaxed)
 }
 
 /// Global active console instance wrapper.
@@ -118,15 +230,44 @@ pub fn init(video_type: VideoModeType) {
 /// Thread-safe: acquires the global spinlock that disables interrupts for the
 /// duration of the closure. This prevents race conditions from concurrent logs
 /// and preemption during screen draws.
+///
+/// Note on VRAM flushing (issue #16): the closure `f` may leave a deferred
+/// VRAM upload queued (e.g. after a `FramebufferConsole` scroll or clear,
+/// which can mark the entire screen dirty). Rather than performing that
+/// upload from inside `f` — which would run the slow, MMIO-bound blit while
+/// this function's lock still has interrupts disabled — we extract it via
+/// [`KernelConsole::take_pending_flush`] (cheap, still under the lock) and
+/// apply it only after the lock guard has been dropped.
 pub fn with_console<R>(f: impl FnOnce(&mut dyn KernelConsole) -> R) -> R {
-    // Step 1: Acquire the spinlock to gain exclusive access and disable interrupts.
-    let mut guard = GLOBAL_CONSOLE.lock();
+    // Step 1: Acquire the spinlock (disables interrupts) and run the closure,
+    // then extract (but do not yet apply) any pending VRAM flush. Both of
+    // these are cheap RAM-only operations, so it is fine to keep them inside
+    // this critical section.
+    let (result, pending_flush) = {
+        let mut guard = GLOBAL_CONSOLE.lock();
 
-    // Step 2: Unwrap the option. Guaranteed to succeed as it is default-initialized.
-    let console = guard
-        .as_mut()
-        .expect("GLOBAL_CONSOLE has not been initialized!");
+        // Step 2: Unwrap the option. Guaranteed to succeed as it is default-initialized.
+        let console = guard
+            .as_mut()
+            .expect("GLOBAL_CONSOLE has not been initialized!");
 
-    // Step 3: Run the user closure against the active console implementation.
-    f(console)
+        // Step 3: Run the user closure against the active console implementation.
+        let result = f(console);
+
+        // Step 4: Snapshot any queued dirty region while still holding the lock.
+        let pending_flush = console.take_pending_flush();
+
+        (result, pending_flush)
+        // `guard` is dropped here, releasing the lock and restoring interrupts
+        // to whatever state they were in before this call.
+    };
+
+    // Step 5: Perform the actual (potentially large) VRAM upload, if any, now
+    // that the lock has been released. This is the fix for issue #16: the
+    // slow MMIO `copy_nonoverlapping` no longer runs with interrupts disabled.
+    if let Some(flush) = pending_flush {
+        flush.apply();
+    }
+
+    result
 }

--- a/main64/kernel/src/console/mod.rs
+++ b/main64/kernel/src/console/mod.rs
@@ -6,7 +6,12 @@
 mod dispatch;
 mod font_basic;
 mod framebuffer;
-mod interface;
+// `interface` is `pub` (rather than private + re-exported like the other
+// submodules) solely so integration tests can reach the test-only
+// introspection hook `interface::last_flush_ran_with_interrupts_enabled`
+// (see issue #16) via its full path, following the same "plain `pub` +
+// `#[doc(hidden)]`" convention used by e.g. `block::reset_active_device`.
+pub mod interface;
 mod vga;
 
 pub use dispatch::ConsoleImpl;

--- a/main64/kernel/tests/console_flush_lock_test.rs
+++ b/main64/kernel/tests/console_flush_lock_test.rs
@@ -1,0 +1,231 @@
+//! Console VRAM-flush lock-scope integration tests (issue #16).
+//!
+//! Before the fix, `console::with_console` held `GLOBAL_CONSOLE`'s
+//! interrupt-disabling spinlock for the *entire* duration of the closure
+//! passed to it, and `FramebufferConsole`'s `KernelConsole` methods performed
+//! the (potentially full-screen) VRAM `copy_nonoverlapping` from *inside*
+//! that closure. Any operation that marks the whole screen dirty (most
+//! notably `FramebufferConsole::scroll`, which marks every scanline dirty
+//! before returning) therefore caused a full-screen MMIO blit to run with
+//! interrupts disabled — a latency spike that can stall the scheduler and
+//! other interrupts.
+//!
+//! These tests exercise the real `console::init` / `console::with_console`
+//! path against a fake linear framebuffer (a heap buffer standing in for
+//! physical VRAM) and use the test-only introspection hook
+//! `console::interface::last_flush_ran_with_interrupts_enabled` to verify
+//! that the deferred VRAM upload now runs *after* `GLOBAL_CONSOLE`'s lock has
+//! been released, not while interrupts are still disabled by it.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+extern crate alloc;
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use kaos_kernel::arch::interrupts;
+use kaos_kernel::boot_info::{
+    BootInfo, FramebufferInfo, PixelFormat, VideoModeType, BOOT_INFO_PTR,
+};
+use kaos_kernel::console;
+use kaos_kernel::memory::{heap, pmm, vmm};
+
+/// Entry point for the console flush-lock integration test kernel.
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+
+    pmm::init(false);
+    interrupts::init();
+    vmm::init(false);
+    heap::init(false);
+
+    test_main();
+
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+/// Panic handler for integration tests.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    kaos_kernel::testing::test_panic_handler(info)
+}
+
+/// Small test-only framebuffer geometry: 10 text columns x 3 text rows
+/// (matching `FramebufferConsole`'s fixed 8x16 glyph size).
+const TEST_COLS: usize = 10;
+const TEST_ROWS: usize = 3;
+const TEST_WIDTH: u32 = (TEST_COLS * 8) as u32;
+const TEST_HEIGHT: u32 = (TEST_ROWS * 16) as u32;
+
+/// RGB value of `Color::White` (`0x00FFFFFF`), which is identical regardless
+/// of RGB/BGR channel order, used below to confirm that rendered glyph pixels
+/// actually made it into the fake VRAM buffer.
+const WHITE_RGB: u32 = 0x00FF_FFFF;
+
+/// Sets up a fake linear framebuffer backed by a heap buffer, installs it as
+/// the active `BootInfo`, initializes the console module in framebuffer mode,
+/// and runs `body` with mutable access to the fake VRAM contents.
+///
+/// On return, the console is switched back to VGA text mode and `BOOT_INFO_PTR`
+/// is cleared *before* the fake VRAM buffer is dropped, so no dangling
+/// pointer into freed heap memory is ever left reachable from
+/// `GLOBAL_CONSOLE` or `BOOT_INFO_PTR` for later tests in this binary.
+fn with_test_framebuffer_console(body: impl FnOnce(&mut Vec<u32>)) {
+    let mut vram: Vec<u32> = vec![0u32; (TEST_WIDTH * TEST_HEIGHT) as usize];
+
+    let boot_info = BootInfo {
+        magic: 0,
+        video_type: VideoModeType::Framebuffer,
+        fb_info: FramebufferInfo {
+            base_address: vram.as_mut_ptr() as u64,
+            size: vram.len() * core::mem::size_of::<u32>(),
+            width: TEST_WIDTH,
+            height: TEST_HEIGHT,
+            pixels_per_scanline: TEST_WIDTH,
+            pixel_format: PixelFormat::Bgr,
+        },
+        memory_map_addr: 0,
+        memory_map_len: 0,
+        kernel_size: 0,
+        pmm_metadata_base: 0,
+        pmm_metadata_size: 0,
+        boot_year: 0,
+        boot_month: 0,
+        boot_day: 0,
+        boot_hour: 0,
+        boot_minute: 0,
+        boot_second: 0,
+        boot_timezone: 0,
+    };
+
+    // SAFETY:
+    // - `boot_info` lives on this function's stack frame, which stays alive
+    //   for the entire duration of `body`, i.e. for as long as anything could
+    //   possibly still read `BOOT_INFO_PTR` on this synchronous, single-core
+    //   test path.
+    // - `console::init` only dereferences the pointer synchronously while
+    //   constructing the new `FramebufferConsole`; it does not retain it.
+    BOOT_INFO_PTR.store(&boot_info as *const BootInfo as u64, Ordering::Relaxed);
+    console::init(VideoModeType::Framebuffer);
+
+    body(&mut vram);
+
+    // Switch back to VGA text mode (dropping the `FramebufferConsole`, whose
+    // stored `fb_info.base_address` would otherwise dangle once `vram` below
+    // is freed) and clear the boot-info pointer, so nothing is left pointing
+    // at this function's soon-to-be-freed stack/heap memory.
+    console::init(VideoModeType::VgaText);
+    BOOT_INFO_PTR.store(0, Ordering::Relaxed);
+}
+
+/// Contract: a deferred flush triggered by a full-screen dirty range (as
+/// produced by `FramebufferConsole::scroll`) is applied by `with_console`
+/// *after* releasing `GLOBAL_CONSOLE`'s lock, so it runs with interrupts
+/// enabled rather than while the lock still has them disabled.
+/// Given: A fake framebuffer console with interrupts enabled beforehand.
+/// When: Enough lines are printed through `with_console` to force a scroll,
+///   which marks the entire screen dirty.
+/// Then: The recorded interrupt state at flush time must be "enabled", and
+///   the fake VRAM buffer must contain the actually-rendered glyph pixels.
+/// Failure Impact: A regression here means the console once again performs a
+///   large MMIO blit while interrupts are disabled (issue #16), reintroducing
+///   the scheduler/interrupt latency spike.
+#[test_case]
+fn test_scroll_triggered_flush_runs_with_interrupts_enabled() {
+    with_test_framebuffer_console(|vram| {
+        interrupts::enable();
+        assert!(
+            interrupts::are_enabled(),
+            "precondition: interrupts must be enabled before the call"
+        );
+
+        console::with_console(|c| {
+            c.clear();
+            // TEST_ROWS + 1 newlines push the cursor one row past the bottom,
+            // forcing FramebufferConsole::scroll() to run and mark the
+            // *entire* screen dirty before with_console returns.
+            for _ in 0..=TEST_ROWS {
+                c.print_str("X\n");
+            }
+        });
+
+        assert!(
+            interrupts::are_enabled(),
+            "with_console must restore the caller's original (enabled) \
+             interrupt state after the call"
+        );
+        assert!(
+            console::interface::last_flush_ran_with_interrupts_enabled(),
+            "the deferred VRAM flush triggered by a full-screen dirty range \
+             (scroll) must run with interrupts enabled, i.e. after \
+             GLOBAL_CONSOLE's lock has been released, not while it still \
+             has interrupts disabled"
+        );
+        assert!(
+            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            "the flush must have actually copied rendered glyph pixels into \
+             the (fake) physical framebuffer, not merely been recorded as a \
+             no-op"
+        );
+
+        interrupts::disable();
+    });
+}
+
+/// Contract: `with_console` never force-enables interrupts around the
+/// deferred flush; if the caller already had interrupts disabled, the flush
+/// still runs (and the console content is still correct), but with
+/// interrupts left disabled throughout.
+/// Given: A fake framebuffer console with interrupts explicitly disabled
+///   beforehand.
+/// When: Enough lines are printed through `with_console` to force a scroll.
+/// Then: The recorded interrupt state at flush time must be "disabled", and
+///   interrupts remain disabled after `with_console` returns, while the
+///   flush still visibly ran (VRAM contains rendered pixels).
+/// Failure Impact: A regression here would mean `with_console` unexpectedly
+///   changes the caller's interrupt state, which could re-enable interrupts
+///   inside another lock's critical section and reintroduce a deadlock risk.
+#[test_case]
+fn test_flush_does_not_force_enable_interrupts_when_caller_had_them_disabled() {
+    with_test_framebuffer_console(|vram| {
+        interrupts::disable();
+        assert!(
+            !interrupts::are_enabled(),
+            "precondition: interrupts must be disabled before the call"
+        );
+
+        console::with_console(|c| {
+            c.clear();
+            for _ in 0..=TEST_ROWS {
+                c.print_str("Y\n");
+            }
+        });
+
+        assert!(
+            !interrupts::are_enabled(),
+            "with_console must restore the caller's original (disabled) \
+             interrupt state after the call"
+        );
+        assert!(
+            !console::interface::last_flush_ran_with_interrupts_enabled(),
+            "with_console must not force-enable interrupts around the \
+             deferred flush when the caller already had them disabled"
+        );
+        assert!(
+            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            "the flush must still have applied even though interrupts were \
+             disabled throughout"
+        );
+    });
+}


### PR DESCRIPTION
Closes #16

## Problem

`console::with_console` held `GLOBAL_CONSOLE`'s `SpinLock` (which disables
interrupts for as long as the guard is alive) for the *entire* duration of
the closure passed to it. `FramebufferConsole`'s `KernelConsole` methods
called `flush_redraw()` → `flush_to_vram()` from inside that closure, doing
a `core::ptr::copy_nonoverlapping` straight to VRAM (slow MMIO) while still
holding the lock. Since `scroll()` (and `clear()`) mark the *entire* screen
dirty before returning, any scroll caused a full-screen VRAM blit to run
with interrupts disabled — a latency spike that can stall the scheduler and
other interrupts.

## Fix

Split "render + compute dirty range" (must stay under the lock — it touches
shared state) from "blit dirty range to VRAM" (moved outside the lock):

- `KernelConsole` gained a new method `take_pending_flush(&mut self) ->
  Option<PendingFlush>`, with a default no-op implementation so backends
  without a backbuffer/dirty-range concept (`VgaConsole`, which writes
  straight to VGA MMIO per character) don't need to do anything.
- `FramebufferConsole` implements it via a new `take_flush_job()` (replacing
  the old `flush_to_vram()`): it snapshots the dirty scanline range from the
  RAM `backbuffer` into a new, never-reallocated `flush_scratch` buffer (a
  fast RAM-to-RAM `memcpy`) and resets dirty tracking — cheap enough to keep
  under the lock. It returns a `PendingFlush` descriptor (raw
  src/dst/len) describing the actual slow VRAM write.
- `with_console` now: runs the closure and calls `take_pending_flush()`
  *inside* the lock scope, then drops the guard (restoring interrupts to
  whatever they were before the call), and only *then* calls
  `PendingFlush::apply()` to perform the real `copy_nonoverlapping` into
  VRAM — outside the interrupt-disabling critical section.
- `ConsoleImpl` (the enum-dispatch wrapper) got an explicit
  `take_pending_flush` delegating to the active variant, since default trait
  methods aren't inherited through delegation matches.

This matches the fix suggested in the issue ("copy the dirty region out
under the lock, then perform the VRAM blit after releasing the lock").

## Testing

Added `kernel/tests/console_flush_lock_test.rs`, a new integration test
binary that drives the real `console::init`/`console::with_console` path
against a fake linear framebuffer (a heap buffer standing in for physical
VRAM) and a small 10x3 text-cell geometry. It uses a new `#[doc(hidden)] pub`
introspection hook, `console::interface::last_flush_ran_with_interrupts_enabled()`
(following the existing convention used by e.g. `block::reset_active_device`),
which records whether interrupts were enabled at the moment the VRAM
`copy_nonoverlapping` actually ran.

Two test cases:
- `test_scroll_triggered_flush_runs_with_interrupts_enabled`: forces a
  scroll (full-screen dirty range) with interrupts enabled beforehand, then
  asserts the flush ran with interrupts enabled and the fake VRAM buffer
  actually received the rendered pixels (not just a no-op).
- `test_flush_does_not_force_enable_interrupts_when_caller_had_them_disabled`:
  same scenario but with interrupts explicitly disabled beforehand, asserting
  `with_console` doesn't spuriously enable interrupts around the flush.

### Verification performed
- `cargo test` (full suite, from `main64/kernel/`): **333/333 test cases
  across 37 test files passed**, including the 2 new tests and all
  pre-existing ones (no regressions).
- `cargo clippy` (from `main64/kernel/`): zero warnings.
- `cargo fmt --check` (from `main64/`): no diff.