### PR TITLE
M6: Gate Shutdown syscall behind a task privilege flag

### DIFF
--- a/main64/kernel/src/main.rs
+++ b/main64/kernel/src/main.rs
@@ -312,8 +312,13 @@ pub extern "C" fn KernelMain(boot_info_raw: u64) -> ! {
 
     // Spawn the user-space shell task from the image loaded above (FAT32 on both
     // paths: ESP via AHCI on UEFI, superfloppy at LBA 0 via ATA on legacy BIOS).
-    let shell_pid =
-        process::exec_from_image(&shell_image).expect("failed to spawn SHELL.BIN user-mode task");
+    //
+    // The shell is the only task granted the privileged-syscall capability at
+    // spawn time (M6, `docs/CODE_REVIEW_2026-07-23.md`): it is the sole
+    // legitimate caller of the `Shutdown` syscall. Every task spawned later
+    // via `Exec` defaults to unprivileged (see `process::exec_from_vfs`).
+    let shell_pid = process::exec_from_image(&shell_image, true)
+        .expect("failed to spawn SHELL.BIN user-mode task");
 
     // On the UEFI path there is no serial console on real hardware, so leave a
     // visible breadcrumb on the framebuffer. If boot stalls after "Starting...",

--- a/main64/kernel/src/process/loader.rs
+++ b/main64/kernel/src/process/loader.rs
@@ -82,9 +82,13 @@ pub fn load_program_into_user_address_space(file_name_8_3: &str) -> ExecResult<L
 ///
 /// On spawn failure, any newly created user address space is destroyed to avoid
 /// leaking process-owned mappings and frames.
+///
+/// Tasks spawned through this path (i.e. via the `Exec` syscall) are always
+/// unprivileged: only the boot shell spawned by [`exec_from_image`] is granted
+/// the privileged-syscall capability (see M6, `docs/CODE_REVIEW_2026-07-23.md`).
 pub fn exec_from_vfs(file_name_8_3: &str) -> ExecResult<usize> {
     let loaded = load_program_into_user_address_space(file_name_8_3)?;
-    spawn_loaded_program(loaded)
+    spawn_loaded_program(loaded, false)
 }
 
 /// End-to-end process exec path for an already-loaded flat user binary.
@@ -100,9 +104,14 @@ pub fn exec_from_vfs(file_name_8_3: &str) -> ExecResult<usize> {
 ///
 /// On spawn failure, the newly created user address space is destroyed to avoid
 /// leaking process-owned mappings and frames.
-pub fn exec_from_image(image: &[u8]) -> ExecResult<usize> {
+///
+/// `privileged` is forwarded unchanged to the scheduler spawn call (see M6,
+/// `docs/CODE_REVIEW_2026-07-23.md`). The boot path passes `true` here for the
+/// initial shell task; callers that load additional images through this
+/// function for any other purpose should pass `false`.
+pub fn exec_from_image(image: &[u8], privileged: bool) -> ExecResult<usize> {
     let loaded = map_program_image_into_user_address_space(image)?;
-    spawn_loaded_program(loaded)
+    spawn_loaded_program(loaded, privileged)
 }
 
 /// Maps a validated flat image into a fresh user address space and copies bytes.
@@ -409,8 +418,16 @@ fn cleanup_failed_program_mapping(user_cr3: u64, state: &MapState) {
 /// Ownership contract:
 /// - on success, scheduler owns `loaded.cr3` lifecycle via task teardown
 /// - on failure, this function destroys `loaded.cr3` immediately
-fn spawn_loaded_program(loaded: LoadedProgram) -> ExecResult<usize> {
-    match scheduler::spawn_user_task_owning_code(loaded.entry_rip, loaded.user_rsp, loaded.cr3) {
+///
+/// `privileged` is forwarded to [`scheduler::spawn_user_task_owning_code`]; see
+/// M6 in `docs/CODE_REVIEW_2026-07-23.md` for what this capability gates.
+fn spawn_loaded_program(loaded: LoadedProgram, privileged: bool) -> ExecResult<usize> {
+    match scheduler::spawn_user_task_owning_code(
+        loaded.entry_rip,
+        loaded.user_rsp,
+        loaded.cr3,
+        privileged,
+    ) {
         Ok(task_id) => Ok(task_id),
         Err(e) => {
             crate::logging::logln(

--- a/main64/kernel/src/scheduler/roundrobin/api.rs
+++ b/main64/kernel/src/scheduler/roundrobin/api.rs
@@ -111,6 +111,21 @@ pub fn is_user_task(task_id: usize) -> bool {
     })
 }
 
+/// Returns whether `task_id` holds the privileged-syscall capability.
+///
+/// `task_id` is a packed task identifier (slot + generation) as returned by
+/// the spawn functions; the generation portion is ignored by this query.
+///
+/// An unused/unknown slot is treated as unprivileged. This is the seed of a
+/// capability model (M6, `docs/CODE_REVIEW_2026-07-23.md`): today it gates
+/// only the `Shutdown` syscall.
+pub fn is_task_privileged(task_id: usize) -> bool {
+    let slot = task_id_slot(task_id);
+    with_scheduler(|meta| {
+        slot < meta.slots.len() && meta.slots[slot].used && meta.slots[slot].privileged
+    })
+}
+
 /// Returns task context tuple `(cr3, user_rsp, kernel_rsp_top)` for `task_id`.
 ///
 /// `task_id` is a packed task identifier (slot + generation) as returned by

--- a/main64/kernel/src/scheduler/roundrobin/mod.rs
+++ b/main64/kernel/src/scheduler/roundrobin/mod.rs
@@ -46,9 +46,9 @@ mod wait;
 
 #[allow(unused_imports)]
 pub use api::{
-    current_task_id, current_user_heap_top, is_user_task, reset_initialization_for_test,
-    set_current_user_heap_top, set_task_user_context, slot_table_len, task_context, task_frame_ptr,
-    task_generation, task_iret_frame, task_state,
+    current_task_id, current_user_heap_top, is_task_privileged, is_user_task,
+    reset_initialization_for_test, set_current_user_heap_top, set_task_user_context,
+    slot_table_len, task_context, task_frame_ptr, task_generation, task_iret_frame, task_state,
 };
 #[allow(unused_imports)]
 pub use spawn::{spawn_kernel_task, spawn_user_task, spawn_user_task_owning_code};

--- a/main64/kernel/src/scheduler/roundrobin/spawn.rs
+++ b/main64/kernel/src/scheduler/roundrobin/spawn.rs
@@ -21,12 +21,23 @@ pub fn spawn_kernel_task(entry: extern "C" fn() -> !) -> Result<usize, SpawnErro
 ///
 /// `entry_rip` and `user_rsp` are user-space virtual addresses in the task's
 /// address space identified by `cr3`.
-pub fn spawn_user_task(entry_rip: u64, user_rsp: u64, cr3: u64) -> Result<usize, SpawnError> {
+///
+/// `privileged` grants the privileged-syscall capability (currently gating
+/// `Shutdown`, see M6 in `docs/CODE_REVIEW_2026-07-23.md`). Callers should
+/// pass `false` unless spawning a task that legitimately needs that
+/// capability (today, only the boot shell).
+pub fn spawn_user_task(
+    entry_rip: u64,
+    user_rsp: u64,
+    cr3: u64,
+    privileged: bool,
+) -> Result<usize, SpawnError> {
     spawn_internal(SpawnKind::User {
         entry_rip,
         user_rsp,
         cr3,
         release_user_code_pfns: false,
+        privileged,
     })
 }
 
@@ -34,16 +45,23 @@ pub fn spawn_user_task(entry_rip: u64, user_rsp: u64, cr3: u64) -> Result<usize,
 ///
 /// Use this for loader-backed binaries that were copied into private PMM
 /// frames. On task teardown these code PFNs are released.
+///
+/// `privileged` grants the privileged-syscall capability (currently gating
+/// `Shutdown`, see M6 in `docs/CODE_REVIEW_2026-07-23.md`). Callers should
+/// pass `false` unless spawning a task that legitimately needs that
+/// capability (today, only the boot shell).
 pub fn spawn_user_task_owning_code(
     entry_rip: u64,
     user_rsp: u64,
     cr3: u64,
+    privileged: bool,
 ) -> Result<usize, SpawnError> {
     spawn_internal(SpawnKind::User {
         entry_rip,
         user_rsp,
         cr3,
         release_user_code_pfns: true,
+        privileged,
     })
 }
 
@@ -118,31 +136,39 @@ fn spawn_internal(kind: SpawnKind) -> Result<usize, SpawnError> {
             .try_reserve(1)
             .map_err(|_| SpawnError::StackAllocationFailed)?;
 
-        let (frame_ptr, cr3, user_rsp, kernel_rsp_top, is_user, release_user_code_pfns) = match kind
-        {
-            SpawnKind::Kernel { entry } => {
-                let (frame_ptr, kernel_rsp_top) =
-                    build_initial_kernel_task_frame(stack_ptr, TASK_STACK_SIZE, entry);
-                (frame_ptr, 0, 0, kernel_rsp_top, false, false)
-            }
-            SpawnKind::User {
-                entry_rip,
-                user_rsp,
-                cr3,
-                release_user_code_pfns,
-            } => {
-                let (frame_ptr, kernel_rsp_top) =
-                    build_initial_user_task_frame(stack_ptr, TASK_STACK_SIZE, entry_rip, user_rsp);
-                (
-                    frame_ptr,
-                    cr3,
+        let (frame_ptr, cr3, user_rsp, kernel_rsp_top, is_user, release_user_code_pfns, privileged) =
+            match kind {
+                SpawnKind::Kernel { entry } => {
+                    let (frame_ptr, kernel_rsp_top) =
+                        build_initial_kernel_task_frame(stack_ptr, TASK_STACK_SIZE, entry);
+                    // Kernel tasks never cross the syscall boundary (they call kernel
+                    // functions directly), so the privileged flag is inert for them.
+                    (frame_ptr, 0, 0, kernel_rsp_top, false, false, false)
+                }
+                SpawnKind::User {
+                    entry_rip,
                     user_rsp,
-                    kernel_rsp_top,
-                    true,
+                    cr3,
                     release_user_code_pfns,
-                )
-            }
-        };
+                    privileged,
+                } => {
+                    let (frame_ptr, kernel_rsp_top) = build_initial_user_task_frame(
+                        stack_ptr,
+                        TASK_STACK_SIZE,
+                        entry_rip,
+                        user_rsp,
+                    );
+                    (
+                        frame_ptr,
+                        cr3,
+                        user_rsp,
+                        kernel_rsp_top,
+                        true,
+                        release_user_code_pfns,
+                        privileged,
+                    )
+                }
+            };
 
         // Step 1: Acquire a fresh generation for this task under the scheduler
         // lock.  Fetching here (rather than before the lock) keeps the atomic
@@ -161,6 +187,7 @@ fn spawn_internal(kind: SpawnKind) -> Result<usize, SpawnError> {
             kernel_rsp_top,
             is_user,
             release_user_code_pfns,
+            privileged,
             stack_base: stack_ptr,
             stack_size: TASK_STACK_SIZE,
             fpu_state: fpu_ptr,

--- a/main64/kernel/src/scheduler/roundrobin/types.rs
+++ b/main64/kernel/src/scheduler/roundrobin/types.rs
@@ -39,6 +39,14 @@ pub enum SpawnKind {
         /// `false` is used for temporary user aliases of kernel code pages.
         /// `true` is used for loader-owned binaries with dedicated code PFNs.
         release_user_code_pfns: bool,
+        /// Whether this task is granted privileged-syscall capability.
+        ///
+        /// This is the seed of a capability model (see M6 in
+        /// `docs/CODE_REVIEW_2026-07-23.md`): today it gates only the
+        /// `Shutdown` syscall. `true` is reserved for the initial boot shell;
+        /// every other user task (in particular anything spawned via `Exec`)
+        /// must default to `false`.
+        privileged: bool,
     },
 }
 
@@ -166,6 +174,15 @@ pub struct TaskEntry {
     /// is destroyed. `false` keeps code PFNs reserved (alias-safe).
     pub release_user_code_pfns: bool,
 
+    /// Whether this task holds the privileged-syscall capability.
+    ///
+    /// Seed of a capability model (M6, `docs/CODE_REVIEW_2026-07-23.md`):
+    /// currently only the `Shutdown` syscall implementation consults this
+    /// flag. Kernel tasks never reach the syscall boundary (they call kernel
+    /// functions directly), so this flag is only meaningful for `is_user`
+    /// tasks and defaults to `false` for everyone except the boot shell.
+    pub privileged: bool,
+
     /// Base address of this task's heap-allocated kernel stack.
     pub stack_base: *mut u8,
 
@@ -198,6 +215,7 @@ impl TaskEntry {
             kernel_rsp_top: 0,
             is_user: false,
             release_user_code_pfns: false,
+            privileged: false,
             stack_base: ptr::null_mut(),
             stack_size: 0,
             fpu_state: ptr::null_mut(),

--- a/main64/kernel/src/syscall/dispatch/process.rs
+++ b/main64/kernel/src/syscall/dispatch/process.rs
@@ -296,8 +296,25 @@ pub fn syscall_wait_impl(task_id: u64) -> SyscallResult<u64> {
 }
 
 /// Implements `Shutdown()`: shuts down the virtual machine.
+///
+/// # Authorization
+/// This is a privileged syscall (M6, `docs/CODE_REVIEW_2026-07-23.md`): every
+/// ring-3 task could otherwise power off the machine. Only tasks whose
+/// `TaskEntry::privileged` capability flag is set (today, only the boot
+/// shell) are authorized; every other caller receives
+/// [`SyscallError::PermissionDenied`] and the machine keeps running.
 pub fn syscall_shutdown_impl() -> SyscallResult<u64> {
-    // Step 1: Trigger system shutdown.
+    // Step 1: Identify the calling task. A missing task context (e.g. called
+    // outside a scheduled task) has nothing to authorize against, so treat it
+    // as unprivileged rather than falling through to shutdown.
+    let task_id = scheduler::current_task_id().ok_or(SyscallError::PermissionDenied)?;
+
+    // Step 2: Deny non-privileged callers before touching any hardware state.
+    if !scheduler::is_task_privileged(task_id) {
+        return Err(SyscallError::PermissionDenied);
+    }
+
+    // Step 3: Trigger system shutdown.
     crate::arch::power::shutdown();
 }
 

--- a/main64/kernel/src/syscall/mod.rs
+++ b/main64/kernel/src/syscall/mod.rs
@@ -23,6 +23,6 @@ pub use types::{
     decode_result, is_valid_user_buffer, is_valid_user_buffer_writable, syscall_error_to_raw,
     syscall_result_to_raw, user_alias_rip, user_alias_va_for_kernel, SysError, SyscallError,
     SyscallId, SyscallResult, UserBiosMemoryRegion, UserDateTime, UserPciBar, UserPciDevice,
-    SYSCALL_ERR_INVALID_ARG, SYSCALL_ERR_IO, SYSCALL_ERR_OUT_OF_MEMORY, SYSCALL_ERR_UNSUPPORTED,
-    SYSCALL_OK,
+    SYSCALL_ERR_INVALID_ARG, SYSCALL_ERR_IO, SYSCALL_ERR_OUT_OF_MEMORY,
+    SYSCALL_ERR_PERMISSION_DENIED, SYSCALL_ERR_UNSUPPORTED, SYSCALL_OK,
 };

--- a/main64/kernel/src/syscall/types.rs
+++ b/main64/kernel/src/syscall/types.rs
@@ -159,6 +159,9 @@ pub const SYSCALL_ERR_IO: u64 = u64::MAX - 2;
 /// Out-of-memory error during syscall execution.
 pub const SYSCALL_ERR_OUT_OF_MEMORY: u64 = u64::MAX - 3;
 
+/// Caller lacks the capability required for this syscall.
+pub const SYSCALL_ERR_PERMISSION_DENIED: u64 = u64::MAX - 4;
+
 /// Successful syscall return code for void-like operations.
 pub const SYSCALL_OK: u64 = 0;
 
@@ -179,6 +182,13 @@ pub enum SyscallError {
 
     /// Out-of-memory error (e.g., physical frame allocator exhausted).
     OutOfMemory,
+
+    /// Caller lacks the capability required for this syscall.
+    ///
+    /// Seed of a capability model (M6, `docs/CODE_REVIEW_2026-07-23.md`):
+    /// currently returned only by the `Shutdown` syscall when the calling
+    /// task is not marked privileged.
+    PermissionDenied,
 }
 
 /// Kernel-internal syscall result type.
@@ -192,6 +202,7 @@ pub const fn syscall_error_to_raw(err: SyscallError) -> u64 {
         SyscallError::InvalidArg => SYSCALL_ERR_INVALID_ARG,
         SyscallError::Io => SYSCALL_ERR_IO,
         SyscallError::OutOfMemory => SYSCALL_ERR_OUT_OF_MEMORY,
+        SyscallError::PermissionDenied => SYSCALL_ERR_PERMISSION_DENIED,
     }
 }
 
@@ -362,6 +373,8 @@ pub enum SysError {
     IoError,
     /// Out-of-memory error (e.g., physical frame allocator exhausted).
     OutOfMemory,
+    /// Caller lacks the capability required for this syscall.
+    PermissionDenied,
     /// Any unclassified kernel return value in the error range.
     Unknown(u64),
 }
@@ -374,6 +387,7 @@ impl core::fmt::Display for SysError {
             SysError::InvalidArgument => write!(f, "InvalidArgument"),
             SysError::IoError => write!(f, "IoError"),
             SysError::OutOfMemory => write!(f, "OutOfMemory"),
+            SysError::PermissionDenied => write!(f, "PermissionDenied"),
             SysError::Unknown(raw) => write!(f, "UnknownError(0x{:x})", raw),
         }
     }
@@ -387,6 +401,7 @@ impl core::fmt::LowerHex for SysError {
             SysError::InvalidArgument => SYSCALL_ERR_INVALID_ARG,
             SysError::IoError => SYSCALL_ERR_IO,
             SysError::OutOfMemory => SYSCALL_ERR_OUT_OF_MEMORY,
+            SysError::PermissionDenied => SYSCALL_ERR_PERMISSION_DENIED,
             SysError::Unknown(raw) => *raw,
         };
         core::fmt::LowerHex::fmt(&val, f)
@@ -402,7 +417,8 @@ pub fn decode_result(raw: u64) -> Result<u64, SysError> {
         SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
         SYSCALL_ERR_IO => Err(SysError::IoError),
         SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
-        x if x >= SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::Unknown(x)),
+        SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::PermissionDenied),
+        x if x >= SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::Unknown(x)),
         value => Ok(value),
     }
 }

--- a/main64/kernel/src/syscall/user.rs
+++ b/main64/kernel/src/syscall/user.rs
@@ -16,16 +16,16 @@ use core::arch::asm;
 
 use super::{
     abi, SysError, SyscallId, SYSCALL_ERR_INVALID_ARG, SYSCALL_ERR_IO, SYSCALL_ERR_OUT_OF_MEMORY,
-    SYSCALL_ERR_UNSUPPORTED,
+    SYSCALL_ERR_PERMISSION_DENIED, SYSCALL_ERR_UNSUPPORTED,
 };
 
 /// Decodes a raw `int 0x80` return value into `Result<u64, SysError>`.
 ///
 /// This is the single authoritative mapping from the raw ABI sentinel values
 /// (`SYSCALL_ERR_*`) to [`SysError`] variants, shared by every wrapper in this
-/// module. The four sentinels occupy the contiguous range
-/// `[SYSCALL_ERR_OUT_OF_MEMORY, SYSCALL_ERR_UNSUPPORTED]` (i.e.
-/// `u64::MAX - 3 ..= u64::MAX`) with no gaps, so matching all four explicitly
+/// module. The five sentinels occupy the contiguous range
+/// `[SYSCALL_ERR_PERMISSION_DENIED, SYSCALL_ERR_UNSUPPORTED]` (i.e.
+/// `u64::MAX - 4 ..= u64::MAX`) with no gaps, so matching all five explicitly
 /// is exhaustive over the entire error range — no additional `x if x >= ...`
 /// catch-all arm is reachable, and any such arm would be dead code.
 ///
@@ -43,6 +43,7 @@ pub const fn decode(raw: u64) -> Result<u64, SysError> {
         SYSCALL_ERR_INVALID_ARG => Err(SysError::InvalidArgument),
         SYSCALL_ERR_IO => Err(SysError::IoError),
         SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
+        SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::PermissionDenied),
         value => Ok(value),
     }
 }
@@ -381,7 +382,7 @@ pub unsafe fn sys_mmap(addr: u64, length: usize) -> Result<*mut u8, SysError> {
     };
 
     // Valid user heap addresses (0x0000_7000_1000_0000...) are safely below the
-    // error sentinel range (u64::MAX - 3 .. u64::MAX) so there is no ambiguity
+    // error sentinel range (u64::MAX - 4 .. u64::MAX) so there is no ambiguity
     // between a successful pointer return and an error code.
     decode(raw_value).map(|ptr| ptr as *mut u8)
 }

--- a/main64/kernel/tests/console_flush_lock_test.rs
+++ b/main64/kernel/tests/console_flush_lock_test.rs
@@ -173,7 +173,7 @@ fn test_scroll_triggered_flush_runs_with_interrupts_enabled() {
              has interrupts disabled"
         );
         assert!(
-            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            vram.contains(&WHITE_RGB),
             "the flush must have actually copied rendered glyph pixels into \
              the (fake) physical framebuffer, not merely been recorded as a \
              no-op"
@@ -223,7 +223,7 @@ fn test_flush_does_not_force_enable_interrupts_when_caller_had_them_disabled() {
              deferred flush when the caller already had them disabled"
         );
         assert!(
-            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            vram.contains(&WHITE_RGB),
             "the flush must still have applied even though interrupts were \
              disabled throughout"
         );

--- a/main64/kernel/tests/heap_test.rs
+++ b/main64/kernel/tests/heap_test.rs
@@ -322,10 +322,10 @@ fn test_small_allocations_round_trip_through_free_list() {
     let layout = Layout::from_size_align(1, 8).unwrap();
 
     // Step 1: Allocate many 1-byte payloads.
-    for i in 0..COUNT {
+    for (i, slot) in ptrs.iter_mut().enumerate() {
         let p = test_heap.allocate(layout);
         assert!(!p.is_null(), "allocation {} should succeed", i);
-        ptrs[i] = p;
+        *slot = p;
     }
 
     // Step 2: Free every other block.  Because the retained blocks stay in use,

--- a/main64/kernel/tests/process_contract_test.rs
+++ b/main64/kernel/tests/process_contract_test.rs
@@ -11,10 +11,12 @@ extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
+use kaos_kernel::arch::interrupts::SavedRegisters;
 use kaos_kernel::arch::{gdt, interrupts};
 use kaos_kernel::memory::{heap, pmm, vmm};
 use kaos_kernel::process;
-use kaos_kernel::scheduler;
+use kaos_kernel::scheduler::{self, TaskState};
+use kaos_kernel::syscall::{self, SyscallId};
 
 #[no_mangle]
 #[link_section = ".text.boot"]
@@ -521,6 +523,142 @@ fn test_exec_from_vfs_maps_invalid_name_error() {
     assert!(
         matches!(result, Err(process::ExecError::InvalidName)),
         "invalid 8.3 input must fail early with ExecError::InvalidName"
+    );
+}
+
+// ── M6: per-syscall authorization (Shutdown capability gate, issue #18) ──
+
+/// Contract: `exec_from_vfs` (the `Exec` syscall path) always spawns an
+/// unprivileged task.
+///
+/// Only the boot shell (spawned via `exec_from_image` with `privileged: true`
+/// in `main.rs`) is granted the privileged-syscall capability. Every task
+/// launched later through `Exec` — including recursively by the shell itself —
+/// must default to unprivileged so it cannot call `Shutdown`.
+#[test_case]
+fn test_exec_from_vfs_spawns_unprivileged_task() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    let task_id =
+        process::exec_from_vfs("hello.bin").expect("hello.bin exec path must spawn user task");
+
+    assert!(
+        !scheduler::is_task_privileged(task_id),
+        "exec_from_vfs must never grant the privileged-syscall capability"
+    );
+
+    assert!(
+        scheduler::terminate_task(task_id),
+        "spawned user task must be terminatable for test cleanup"
+    );
+}
+
+/// Contract: `Shutdown` is denied for an unprivileged running task, and the
+/// machine does not shut down.
+///
+/// This is the concrete fix for issue #18 (M6 — no per-syscall
+/// authorization): previously any ring-3 task could call `Shutdown` and power
+/// off the machine. A task spawned through the `Exec` syscall path is never
+/// privileged, so dispatching `Shutdown` while it is the running task must be
+/// rejected with `SYSCALL_ERR_PERMISSION_DENIED` before
+/// `arch::power::shutdown()` is ever reached.
+#[test_case]
+fn test_shutdown_denied_for_unprivileged_running_task() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    let task_id =
+        process::exec_from_vfs("hello.bin").expect("hello.bin exec path must spawn user task");
+    assert!(
+        !scheduler::is_task_privileged(task_id),
+        "precondition: exec-spawned task must be unprivileged"
+    );
+
+    // Step 1: Select the freshly spawned task so it becomes the scheduler's
+    // current task — the same state `syscall_shutdown_impl` inspects via
+    // `scheduler::current_task_id()`.
+    scheduler::start();
+    let mut bootstrap = SavedRegisters::default();
+    let selected = scheduler::on_timer_tick(&mut bootstrap as *mut SavedRegisters);
+    assert_eq!(
+        selected,
+        scheduler::task_frame_ptr(task_id).expect("spawned task must expose a frame pointer"),
+        "first tick must select the freshly spawned unprivileged task"
+    );
+
+    // Step 2: Dispatching Shutdown while this unprivileged task is current
+    // must be denied, never reaching `arch::power::shutdown()`.
+    let ret = syscall::dispatch(SyscallId::Shutdown as u64, 0, 0, 0, 0);
+    assert_eq!(
+        ret,
+        syscall::SYSCALL_ERR_PERMISSION_DENIED,
+        "unprivileged task must not be authorized to shut down the machine"
+    );
+
+    // Step 3: Prove the machine did not shut down: the task's lifecycle state
+    // is untouched and the scheduler is still tracking it normally.
+    assert_eq!(
+        scheduler::task_state(task_id),
+        Some(TaskState::Running),
+        "a denied Shutdown call must not alter the calling task's lifecycle state"
+    );
+
+    assert!(
+        scheduler::terminate_task(task_id),
+        "spawned user task must be terminatable for test cleanup"
+    );
+}
+
+/// Contract: a task spawned with the privileged capability satisfies the
+/// `Shutdown` syscall's authorization check.
+///
+/// This test intentionally stops short of invoking the `Shutdown` syscall
+/// itself: for an authorized caller, `syscall_shutdown_impl` calls
+/// `arch::power::shutdown()`, which never returns and would tear down the
+/// test QEMU instance before it could report a pass/fail result via
+/// `isa-debug-exit`. Instead this verifies the exact state
+/// `syscall_shutdown_impl` consults — `current_task_id()` combined with
+/// `is_task_privileged()` — proving a privileged task reaches (and passes)
+/// the same authorization gate that the previous test proves denies an
+/// unprivileged one.
+#[test_case]
+fn test_privileged_running_task_passes_shutdown_authorization_check() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    let user_cr3 = vmm::clone_kernel_pml4_for_user();
+    let task_id = scheduler::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        user_cr3,
+        true,
+    )
+    .expect("privileged user task should spawn");
+    assert!(
+        scheduler::is_task_privileged(task_id),
+        "precondition: spawn_user_task(.., privileged=true) must grant the capability"
+    );
+
+    scheduler::start();
+    let mut bootstrap = SavedRegisters::default();
+    let selected = scheduler::on_timer_tick(&mut bootstrap as *mut SavedRegisters);
+    assert_eq!(
+        selected,
+        scheduler::task_frame_ptr(task_id).expect("spawned task must expose a frame pointer"),
+        "first tick must select the freshly spawned privileged task"
+    );
+
+    let current = scheduler::current_task_id().expect("a task must be current after selection");
+    assert!(
+        scheduler::is_task_privileged(current),
+        "the currently running task must report privileged, matching the state \
+         syscall_shutdown_impl's authorization check consults"
+    );
+
+    assert!(
+        scheduler::terminate_task(task_id),
+        "spawned user task must be terminatable for test cleanup"
     );
 }
 

--- a/main64/kernel/tests/scheduler_rr_test.rs
+++ b/main64/kernel/tests/scheduler_rr_test.rs
@@ -11,7 +11,7 @@ use core::sync::atomic::{AtomicU64, Ordering};
 use kaos_kernel::arch::gdt;
 use kaos_kernel::arch::interrupts::{self, SavedRegisters};
 use kaos_kernel::memory::{heap, pmm, vmm};
-use kaos_kernel::scheduler::{self as sched, SchedulerArchCallbacks, TaskState};
+use kaos_kernel::scheduler::{self as sched, SchedulerArchCallbacks, TaskEntry, TaskState};
 use kaos_kernel::sync::singlewaitqueue::SingleWaitQueue;
 use kaos_kernel::sync::waitqueue::WaitQueue;
 use kaos_kernel::sync::waitqueue_adapter;
@@ -95,6 +95,67 @@ fn test_start_without_tasks_does_not_enter_running_state() {
     assert!(
         !sched::is_running(),
         "scheduler must stay stopped when start is called without tasks"
+    );
+}
+
+/// Contract: an empty/unused task slot defaults to unprivileged.
+///
+/// Seed of a capability model (M6, `docs/CODE_REVIEW_2026-07-23.md`): a slot
+/// that was never explicitly granted the privileged-syscall capability (e.g.
+/// via `spawn_user_task(.., privileged: true)`) must never report as
+/// privileged, so a freshly grown/reused slot cannot accidentally authorize
+/// `Shutdown` before a task is spawned into it.
+#[test_case]
+fn test_task_entry_empty_defaults_to_unprivileged() {
+    let entry = TaskEntry::empty();
+    assert!(
+        !entry.privileged,
+        "an empty/unused task slot must never report the privileged capability"
+    );
+}
+
+/// Contract: `spawn_user_task` honors the explicit `privileged` argument in both directions.
+///
+/// This is the scheduler-level half of the M6 fix (issue #18): the capability
+/// flag threaded through `spawn_user_task`/`spawn_user_task_owning_code` must
+/// be tracked per task and observable via `is_task_privileged`, independent of
+/// any syscall dispatch.
+#[test_case]
+fn test_spawn_user_task_privileged_flag_is_tracked() {
+    sched::init();
+
+    let unprivileged_cr3 = vmm::clone_kernel_pml4_for_user();
+    let unprivileged = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        unprivileged_cr3,
+        false,
+    )
+    .expect("unprivileged user task should spawn");
+    assert!(
+        !sched::is_task_privileged(unprivileged),
+        "privileged=false must not grant the privileged-syscall capability"
+    );
+    assert!(
+        sched::terminate_task(unprivileged),
+        "cleanup: unprivileged task must terminate"
+    );
+
+    let privileged_cr3 = vmm::clone_kernel_pml4_for_user();
+    let privileged = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        privileged_cr3,
+        true,
+    )
+    .expect("privileged user task should spawn");
+    assert!(
+        sched::is_task_privileged(privileged),
+        "privileged=true must grant the privileged-syscall capability"
+    );
+    assert!(
+        sched::terminate_task(privileged),
+        "cleanup: privileged task must terminate"
     );
 }
 
@@ -402,8 +463,13 @@ fn test_terminate_active_user_task_switches_to_kernel_cr3_via_callback() {
 
     sched::init();
 
-    let user_task = sched::spawn_user_task(vmm::USER_CODE_BASE, vmm::USER_STACK_TOP - 16, user_cr3)
-        .expect("user task spawn should succeed");
+    let user_task = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        user_cr3,
+        false,
+    )
+    .expect("user task spawn should succeed");
 
     sched::start();
 
@@ -854,7 +920,7 @@ fn test_spawn_user_builds_ring3_iret_frame_with_configured_selectors_and_pointer
     let user_rsp = 0x0000_7FFF_EFFF_F000u64;
     let user_cr3 = 0x0000_0000_0040_0000u64;
 
-    let task_id = sched::spawn_user_task(user_entry, user_rsp, user_cr3)
+    let task_id = sched::spawn_user_task(user_entry, user_rsp, user_cr3, false)
         .expect("user task spawn should succeed");
 
     assert!(
@@ -907,8 +973,13 @@ fn test_scheduler_switches_cr3_between_kernel_and_user_tasks_when_enabled() {
     let kernel_frame = sched::task_frame_ptr(kernel_task).expect("kernel task frame should exist");
 
     let user_cr3 = vmm::clone_kernel_pml4_for_user();
-    let user_task = sched::spawn_user_task(vmm::USER_CODE_BASE, vmm::USER_STACK_TOP - 16, user_cr3)
-        .expect("user task spawn should succeed");
+    let user_task = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        user_cr3,
+        false,
+    )
+    .expect("user task spawn should succeed");
     let user_frame = sched::task_frame_ptr(user_task).expect("user task frame should exist");
 
     sched::start();
@@ -958,8 +1029,13 @@ fn test_reaping_user_task_destroys_its_address_space() {
     sched::set_kernel_address_space_cr3(kernel_cr3);
 
     let user_cr3 = vmm::clone_kernel_pml4_for_user();
-    let user_task = sched::spawn_user_task(vmm::USER_CODE_BASE, vmm::USER_STACK_TOP - 16, user_cr3)
-        .expect("user task spawn should succeed");
+    let user_task = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        user_cr3,
+        false,
+    )
+    .expect("user task spawn should succeed");
 
     sched::start();
 
@@ -1912,8 +1988,13 @@ fn test_user_task_mmap_syscall() {
     sched::init();
 
     // Step 1: Spawn user task. We want to test the mmap syscall, so it must be a user task.
-    let user_task = sched::spawn_user_task(vmm::USER_CODE_BASE, vmm::USER_STACK_TOP - 16, user_cr3)
-        .expect("user task spawn should succeed");
+    let user_task = sched::spawn_user_task(
+        vmm::USER_CODE_BASE,
+        vmm::USER_STACK_TOP - 16,
+        user_cr3,
+        false,
+    )
+    .expect("user task spawn should succeed");
 
     sched::start();
 

--- a/main64/kernel/tests/serial_deadlock_test.rs
+++ b/main64/kernel/tests/serial_deadlock_test.rs
@@ -41,7 +41,7 @@ impl fmt::Display for FaultingFormatter {
         // Trigger a #PF by reading from a non-present address.
         // We use address 0x0 which is not mapped in the kernel.
         unsafe {
-            let _ = core::ptr::read_volatile(0x0 as *const u8);
+            let _ = core::ptr::read_volatile(core::ptr::null::<u8>());
         }
         Ok(())
     }

--- a/main64/kernel/tests/syscall_dispatch_test.rs
+++ b/main64/kernel/tests/syscall_dispatch_test.rs
@@ -411,7 +411,7 @@ fn test_decode_result_maps_known_errors() {
 /// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
 #[test_case]
 fn test_decode_result_accepts_value_below_error_sentinels() {
-    let raw = syscall::SYSCALL_ERR_OUT_OF_MEMORY - 1;
+    let raw = syscall::SYSCALL_ERR_PERMISSION_DENIED - 1;
     assert!(
         syscall::decode_result(raw) == Ok(raw),
         "value below reserved error sentinels must remain a successful return"
@@ -520,14 +520,14 @@ fn test_user_decode_does_not_misclassify_io_or_oom_as_success() {
 
 /// Contract: `syscall::user::decode` keeps values below the error sentinel
 /// range as success, including the boundary value directly adjacent to the
-/// lowest sentinel (`SYSCALL_ERR_OUT_OF_MEMORY`).
-/// Given: The value immediately below `SYSCALL_ERR_OUT_OF_MEMORY`.
+/// lowest sentinel (`SYSCALL_ERR_PERMISSION_DENIED`).
+/// Given: The value immediately below `SYSCALL_ERR_PERMISSION_DENIED`.
 /// When: It is passed to `syscall::user::decode`.
 /// Then: It must decode to `Ok` with the value unchanged.
 /// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
 #[test_case]
 fn test_user_decode_accepts_value_just_below_error_sentinels() {
-    let raw = syscall::SYSCALL_ERR_OUT_OF_MEMORY - 1;
+    let raw = syscall::SYSCALL_ERR_PERMISSION_DENIED - 1;
     assert!(
         syscall::user::decode(raw) == Ok(raw),
         "value directly below the lowest error sentinel must remain a successful return"
@@ -769,7 +769,7 @@ fn test_writable_user_buffer_rejects_read_only_page_after_boundary() {
         "a range crossing into a read-only page must be rejected"
     );
 
-    let ret = syscall::dispatch(SyscallId::GetTime as u64, (first_va + 128) as u64, 0, 0, 0);
+    let ret = syscall::dispatch(SyscallId::GetTime as u64, first_va + 128, 0, 0, 0);
     assert_eq!(
         ret,
         syscall::SYSCALL_OK,

--- a/main64/kernel/tests/time_test.rs
+++ b/main64/kernel/tests/time_test.rs
@@ -77,7 +77,7 @@ fn test_calibrate_tsc_returns_plausible_value() {
         "calibrated TSC frequency must be positive"
     );
     assert!(
-        ticks_per_us >= 10 && ticks_per_us <= 20_000,
+        (10..=20_000).contains(&ticks_per_us),
         "calibrated TSC frequency {} is outside plausible CPU range",
         ticks_per_us
     );

--- a/main64/kernel/tests/user_mode_iretq_smoke_test.rs
+++ b/main64/kernel/tests/user_mode_iretq_smoke_test.rs
@@ -128,7 +128,7 @@ fn test_one_user_task_is_reached_via_scheduler_irq_iretq_path() {
     let kernel_cr3 = vmm::get_pml4_address();
     scheduler::set_kernel_address_space_cr3(kernel_cr3);
     scheduler::spawn_kernel_task(observer_task).expect("observer kernel task spawn should succeed");
-    scheduler::spawn_user_task(USER_CODE_VA, USER_STACK_TOP_ALIGNED, user_cr3)
+    scheduler::spawn_user_task(USER_CODE_VA, USER_STACK_TOP_ALIGNED, user_cr3, false)
         .expect("spawn_user should succeed");
     scheduler::start();
 


### PR DESCRIPTION
## Summary

Closes #18.

Every ring-3 task could previously call `Shutdown` and power off the machine
— there was no per-syscall authorization at all. This adds the incremental
capability seed described in the issue:

- A `privileged: bool` field on the scheduler's `TaskEntry` (and the
  corresponding `SpawnKind::User` variant), defaulting to `false` in
  `TaskEntry::empty()`.
- `spawn_user_task` / `spawn_user_task_owning_code` now take an explicit
  `privileged: bool` parameter, threaded through the process loader
  (`spawn_loaded_program`, `exec_from_image`). `main.rs` passes `true` only
  for the boot shell (`SHELL.BIN`) — the sole legitimate caller of
  `Shutdown` today. `exec_from_vfs` (the `Exec` syscall path) always spawns
  unprivileged tasks, so anything launched via `Exec` — including
  recursively by the shell — cannot shut down the machine.
- A new `scheduler::is_task_privileged(task_id)` accessor, mirroring the
  existing `is_user_task` pattern.
- `syscall_shutdown_impl` now resolves the calling task via
  `scheduler::current_task_id()` and returns a new
  `SyscallError::PermissionDenied` (raw ABI sentinel
  `SYSCALL_ERR_PERMISSION_DENIED = u64::MAX - 4`) instead of shutting down,
  unless the caller is privileged.
- The new sentinel is wired through `syscall_error_to_raw`, the user-facing
  `SysError` enum (`Display`/`LowerHex`), and both decoders
  (`syscall::decode_result` and `syscall::user::decode`). `lib_kaos` shares
  `kernel/src/syscall/types.rs` via a path import, so no separate constant
  list needed updating — but the decode boundary check in both decoders had
  to move down to the new lowest sentinel so the new value isn't
  misclassified as success (the same class of bug the M8 fix, issue #20,
  addressed).
- Kernel tasks never cross the syscall boundary (they call kernel functions
  directly), so the privilege flag is inert for them and always `false`.

Also fixed a handful of pre-existing clippy lints (`manual_range_contains`,
`needless_range_loop`, `unnecessary_cast`, `manual_contains`, `zero_ptr`) in
unrelated test files that were blocking the `-D warnings` gate required for
this PR — none of these files were otherwise touched by the M6 change.

## Test plan

- [x] Added `kernel/tests/scheduler_rr_test.rs::test_task_entry_empty_defaults_to_unprivileged`
- [x] Added `kernel/tests/scheduler_rr_test.rs::test_spawn_user_task_privileged_flag_is_tracked`
- [x] Added `kernel/tests/process_contract_test.rs::test_exec_from_vfs_spawns_unprivileged_task`
- [x] Added `kernel/tests/process_contract_test.rs::test_shutdown_denied_for_unprivileged_running_task`
      (spawns+selects a real unprivileged task, dispatches `Shutdown`, asserts
      `SYSCALL_ERR_PERMISSION_DENIED` and that the task's lifecycle state is
      unaffected — i.e. the machine did not shut down)
- [x] Added `kernel/tests/process_contract_test.rs::test_privileged_running_task_passes_shutdown_authorization_check`
      (spawns+selects a privileged task and verifies it passes the exact
      `current_task_id()` + `is_task_privileged()` check `syscall_shutdown_impl`
      uses, without invoking the syscall itself — `arch::power::shutdown()`
      never returns and would tear down the test QEMU instance before it
      could report a result)
- [x] `cargo test` from `main64/kernel` — full suite passes: **351/351 test
      cases across 37 test files**, no regressions
- [x] `cargo clippy --workspace --target x86_64-unknown-none -- -D warnings`
      from `main64/` (lib+bin targets; `--all-targets` isn't meaningful here
      since this bare-metal workspace can't build std's synthetic `test`
      harness for `x86_64-unknown-none`/`x86_64-unknown-uefi`) — clean
- [x] `cargo clippy --tests -- -D warnings` from `main64/kernel` (the
      project's actual, custom no_std integration-test harness) — clean
- [x] `cargo fmt --check` from `main64/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)