### PR TITLE
M3: Add PMM frame refcounting, reclaim mmap regions on teardown

### DIFF
--- a/main64/docs/pmm.md
+++ b/main64/docs/pmm.md
@@ -296,13 +296,25 @@ Contains metadata for a single physical memory block.
 ```rust
 #[repr(C)]
 pub struct PmmRegion {
-    pub start: u64,         // Physical start address of the region
-    pub frames_total: u64,  // Total frames in the region
-    pub frames_free: u64,   // Free frames remaining
-    pub bitmap_start: u64,  // Physical start address of the region's bitmap
-    pub bitmap_bytes: u64,  // Size of the bitmap in bytes (aligned to 8 bytes)
+    pub start: u64,           // Physical start address of the region
+    pub frames_total: u64,    // Total frames in the region
+    pub frames_free: u64,     // Free frames remaining
+    pub bitmap_start: u64,    // Physical start address of the region's bitmap
+    pub bitmap_bytes: u64,    // Size of the bitmap in bytes (aligned to 8 bytes)
+    pub refcount_start: u64,  // Physical start address of the region's per-frame refcount array
+    pub refcount_bytes: u64,  // Size of the refcount array in bytes (1 byte/frame, aligned to 8)
 }
 ```
+
+Each region also carries a per-frame refcount array (one `u8` per frame, indexed
+identically to the bitmap), placed right after all bitmaps in the metadata layout.
+`alloc_frame()` initializes a fresh frame's byte to `1`. Code that deliberately aliases
+an already-allocated frame into an additional mapping calls `inc_refcount(pfn)` once per
+extra owner. `release_pfn(pfn)` always decrements the count; it only clears the bitmap
+bit (actually freeing the frame) once the count reaches zero, so a shared frame survives
+exactly as many `release_pfn` calls as it has owners. This replaces the old
+`release_user_code_pfns` boolean policy that used to guard user-code/kernel-text aliasing
+by hand (see `memory/vmm/mapping.rs`).
 
 ### `PageFrame`
 A logical handle returned upon successful allocation.
@@ -341,7 +353,8 @@ When the kernel initializes the PMM during `init()`, the following steps are per
    - *UEFI*: the `PmmLayoutHeader` starts at `BootInfo.pmm_metadata_base` (page-aligned). The
      loader sized this region to the machine's RAM and allocated it via
      `AllocatePages(AllocateAnyPages, …)` while boot services were alive, precisely because the
-     bitmap is far too large to fit in low memory on big-RAM systems (~32 KiB per GiB → ~4 MiB at
+     bitmap + refcount array are far too large to fit in low memory on big-RAM systems
+     (bitmap: ~32 KiB per GiB; refcount array: ~256 KiB per GiB → combined ~4 MiB + ~32 MiB at
      128 GiB).
    - *BIOS / fallback*: the end of the kernel virtual address space (`__bss_end`) is converted to
      a physical address via `virt_to_phys()` and aligned up to 4 KiB; that defines the start of

--- a/main64/kaosldr_uefi/src/main.rs
+++ b/main64/kaosldr_uefi/src/main.rs
@@ -789,8 +789,11 @@ pub unsafe extern "efiapi" fn efi_main(
                     region_count += 1;
                 }
             }
-            // header + region array + 1 bit per frame, plus generous slack.
-            let meta_bytes = 0x4000 + region_count * 0x40 + (total_frames / 8) + 0x4000;
+            // header + region array + 1 bit per frame (allocation bitmap) +
+            // 1 byte per frame (per-frame PMM refcount array, see
+            // `kernel/src/memory/pmm/manager.rs`), plus generous slack.
+            let meta_bytes =
+                0x4000 + region_count * 0x40 + (total_frames / 8) + total_frames + 0x4000;
 
             // Step 5b: Calculate how many pages we need to hold the PMM metadata,
             // rounding up the byte size to the nearest page boundary.

--- a/main64/kernel/src/memory/pmm/manager.rs
+++ b/main64/kernel/src/memory/pmm/manager.rs
@@ -149,12 +149,16 @@ impl PhysicalMemoryManager {
                         let frames = entry.size / PAGE_SIZE;
                         let bitmap_bytes = align_up(frames.div_ceil(8), 8);
 
+                        let refcount_bytes = align_up(frames, 8);
+
                         regions[idx] = PmmRegion {
                             start: entry.start,
                             frames_total: frames,
                             frames_free: frames,
                             bitmap_start: 0,
                             bitmap_bytes,
+                            refcount_start: 0,
+                            refcount_bytes,
                         };
                         idx += 1;
                     }
@@ -202,6 +206,7 @@ impl PhysicalMemoryManager {
                 if r.region_type == 1 && r.start >= KERNEL_OFFSET {
                     let frames = r.size / PAGE_SIZE;
                     let bitmap_bytes = align_up(frames.div_ceil(8), 8);
+                    let refcount_bytes = align_up(frames, 8);
 
                     regions[idx] = PmmRegion {
                         start: r.start,
@@ -209,6 +214,8 @@ impl PhysicalMemoryManager {
                         frames_free: frames,
                         bitmap_start: 0,
                         bitmap_bytes,
+                        refcount_start: 0,
+                        refcount_bytes,
                     };
                     idx += 1;
                 }
@@ -232,10 +239,27 @@ impl PhysicalMemoryManager {
             bitmap_base += r.bitmap_bytes;
         }
 
+        // Per-frame refcount arrays follow immediately after all bitmaps, one byte
+        // per frame per region, in the same region order. A zeroed refcount means
+        // "not currently PMM-tracked as allocated"; `alloc_frame` sets a fresh
+        // frame's byte to 1, and `release_pfn`/`inc_refcount` maintain it from there.
+        let mut refcount_base = bitmap_base;
+
+        for r in regions.iter_mut() {
+            r.refcount_start = refcount_base;
+            // SAFETY:
+            // - `refcount_start..refcount_start+refcount_bytes` is PMM-owned metadata memory.
+            // - We clear each refcount array once before allocator use.
+            unsafe {
+                core::ptr::write_bytes(r.refcount_start as *mut u8, 0, r.refcount_bytes as usize)
+            };
+            refcount_base += r.refcount_bytes;
+        }
+
         // Mark the kernel, stack, and PMM metadata as used.
-        // `bitmap_base` already points past the last bitmap, so it is the
+        // `refcount_base` already points past the last refcount array, so it is the
         // true end of all PMM metadata.
-        let metadata_end = bitmap_base;
+        let metadata_end = refcount_base;
 
         if metadata_base == kernel_end_phys {
             // BIOS / fallback path: the metadata sits contiguously right after the
@@ -382,6 +406,16 @@ impl PhysicalMemoryManager {
                         unsafe { set_bit(bit_idx, bitmap) };
                         r.frames_free -= 1;
 
+                        // A freshly allocated frame starts with exactly one owner.
+                        // `inc_refcount`/`release_pfn` maintain this from here on.
+                        // SAFETY:
+                        // - `bit_idx < frames_total` ensures the offset is within the
+                        //   refcount array (sized `frames_total` bytes, aligned up).
+                        // - `refcount_start` points to writable PMM-owned metadata memory.
+                        unsafe {
+                            *(r.refcount_start as *mut u8).add(bit_idx as usize) = 1;
+                        }
+
                         // Log the allocation
                         let pfn = r.start / PAGE_SIZE + bit_idx;
                         let region_index = idx as u32;
@@ -396,10 +430,81 @@ impl PhysicalMemoryManager {
         None
     }
 
+    /// Increments the reference count of an already-allocated frame.
+    ///
+    /// Call this whenever an additional owner starts referencing a physical
+    /// frame that PMM already considers allocated — e.g. a physical frame
+    /// aliased into a second virtual mapping (a user address space's code
+    /// window pointing at a frame another mapping already owns). Each
+    /// `inc_refcount` must be balanced by exactly one extra `release_pfn`
+    /// call before the frame is actually freed.
+    ///
+    /// Returns `true` when the PFN belongs to a known region and is currently
+    /// allocated (bitmap bit set). Returns `false` when the PFN is outside all
+    /// regions, or is not currently allocated — incrementing the refcount of a
+    /// free frame would be a logic error in the caller, so this is rejected
+    /// rather than silently creating a phantom reference.
+    pub fn inc_refcount(&mut self, pfn: u64) -> bool {
+        let regions = self.regions();
+
+        for r in regions.iter_mut() {
+            let region_start_pfn = r.start / PAGE_SIZE;
+            let region_end_pfn = region_start_pfn + r.frames_total;
+            if pfn < region_start_pfn || pfn >= region_end_pfn {
+                continue;
+            }
+
+            let bit_idx = pfn - region_start_pfn;
+            let bitmap = r.bitmap_start as *mut u64;
+            let word_idx = (bit_idx / 64) as usize;
+            let bit_mask = 1u64 << (bit_idx % 64);
+
+            // SAFETY:
+            // - `bit_idx` is derived from a PFN proven to be inside this region.
+            // - Therefore `word_idx` addresses a valid bitmap word.
+            let word_val = unsafe { *bitmap.add(word_idx) };
+
+            if (word_val & bit_mask) == 0 {
+                // Not currently allocated: refusing avoids creating a refcount
+                // for a frame the allocator considers free.
+                return false;
+            }
+
+            // SAFETY:
+            // - `bit_idx < frames_total` ensures the offset is within the
+            //   refcount array for this region.
+            // - `refcount_start` points to writable PMM-owned metadata memory.
+            let refcount_ptr = unsafe { (r.refcount_start as *mut u8).add(bit_idx as usize) };
+            // SAFETY: `refcount_ptr` is valid per the computation above.
+            let count = unsafe { *refcount_ptr };
+
+            // A `u8` comfortably covers realistic sharing counts (kernel +
+            // every process aliasing one frame would need >255 processes).
+            // Saturate instead of wrapping so a pathological caller cannot
+            // wrap the count back down to a small number and cause an early
+            // free while owners still exist.
+            let new_count = count.saturating_add(1);
+            // SAFETY: `refcount_ptr` is valid per the computation above.
+            unsafe { *refcount_ptr = new_count };
+
+            return true;
+        }
+
+        false
+    }
+
     /// Releases a page frame identified by PFN.
     ///
-    /// Returns `true` when the PFN belongs to a known region and was marked used.
-    /// Returns `false` when the PFN is outside all regions or already free.
+    /// Decrements the frame's refcount. If other owners remain (refcount is
+    /// still greater than zero after the decrement), the frame stays
+    /// allocated and this call is a bookkeeping no-op beyond the decrement —
+    /// it still returns `true` because the release itself was valid. Only
+    /// when the last owner releases the frame (refcount reaches zero) is the
+    /// bitmap bit actually cleared and the frame returned to the free pool.
+    ///
+    /// Returns `true` when the PFN belongs to a known region and was marked
+    /// used. Returns `false` when the PFN is outside all regions or already
+    /// free.
     pub fn release_pfn(&mut self, pfn: u64) -> bool {
         let regions = self.regions();
 
@@ -426,6 +531,28 @@ impl PhysicalMemoryManager {
             if (word_val & bit_mask) == 0 {
                 return false;
             }
+
+            // SAFETY:
+            // - `bit_idx < frames_total` ensures the offset is within the
+            //   refcount array for this region.
+            // - `refcount_start` points to writable PMM-owned metadata memory.
+            let refcount_ptr = unsafe { (r.refcount_start as *mut u8).add(bit_idx as usize) };
+            // SAFETY: `refcount_ptr` is valid per the computation above.
+            let count = unsafe { *refcount_ptr };
+
+            if count > 1 {
+                // Other owners remain: only decrement, keep the frame allocated.
+                // SAFETY: `refcount_ptr` is valid per the computation above.
+                unsafe { *refcount_ptr = count - 1 };
+                return true;
+            }
+
+            // Last owner (count == 1) — or a defensive fallback for count == 0,
+            // which should not happen for a frame whose bitmap bit is set, but
+            // is handled the same way (actually free) rather than leaking the
+            // frame forever.
+            // SAFETY: `refcount_ptr` is valid per the computation above.
+            unsafe { *refcount_ptr = 0 };
 
             // SAFETY:
             // - `bit_idx` belongs to this region and currently marks an allocated frame.

--- a/main64/kernel/src/memory/pmm/types.rs
+++ b/main64/kernel/src/memory/pmm/types.rs
@@ -78,6 +78,22 @@ pub struct PmmRegion {
 
     /// Size of the bitmap in bytes (aligned to 8)
     pub bitmap_bytes: u64,
+
+    /// Physical address of the per-frame refcount array for this region.
+    ///
+    /// One `u8` per frame, indexed the same way as the bitmap (`bit_idx` /
+    /// frame offset from `start`). A freshly allocated frame (via
+    /// [`alloc_frame`](super::manager::PhysicalMemoryManager::alloc_frame))
+    /// starts at refcount `1`. Additional owners (e.g. a physical frame
+    /// aliased into more than one virtual mapping) call
+    /// [`inc_refcount`](super::manager::PhysicalMemoryManager::inc_refcount)
+    /// to bump it. [`release_pfn`](super::manager::PhysicalMemoryManager::release_pfn)
+    /// only actually frees the frame (clears the bitmap bit) once the count
+    /// reaches zero.
+    pub refcount_start: u64,
+
+    /// Size of the refcount array in bytes (aligned to 8; one byte per frame).
+    pub refcount_bytes: u64,
 }
 
 #[inline]

--- a/main64/kernel/src/memory/vmm/mapping.rs
+++ b/main64/kernel/src/memory/vmm/mapping.rs
@@ -9,8 +9,9 @@ use super::page_table::{
     PML4_TABLE_ADDR,
 };
 use super::{
-    classify_user_region, debug_alloc, vmm_logln, UserRegion, TEMP_CLONE_PML4_VA, USER_CODE_BASE,
-    USER_CODE_SIZE, USER_HEAP_BASE, USER_HEAP_END, USER_STACK_SIZE, USER_STACK_TOP,
+    classify_user_region, debug_alloc, vmm_logln, UserRegion, TEMP_CLONE_PML4_VA,
+    USER_ADDRESS_SPACE_SCAN_END, USER_CODE_BASE, USER_CODE_SIZE, USER_HEAP_BASE, USER_HEAP_END,
+    USER_STACK_SIZE, USER_STACK_TOP,
 };
 
 /// Error returned by checked mapping operations.
@@ -587,49 +588,20 @@ pub fn clone_kernel_pml4_for_user() -> u64 {
 /// Destroys a user address space rooted at `pml4_phys`.
 ///
 /// Teardown semantics:
-/// - unmaps user-code and user-stack ranges,
-/// - releases mapped PMM-managed leaf frames in stack range,
-/// - keeps code-range leaf PFNs reserved (alias-safe default),
+/// - unmaps user-code, user-stack, and user-heap ranges,
+/// - reclaims any other present user mapping outside those three windows
+///   (e.g. a future `mmap`-created region) via a generic catch-all scan,
+/// - releases every mapped PMM-managed leaf frame it unmaps through the
+///   refcounted `PhysicalMemoryManager::release_pfn`, which only actually
+///   frees a frame once its last owner releases it — so frames shared with
+///   another mapping (via `inc_refcount` at the site that created the alias)
+///   safely survive this call and are freed later, when their other owner
+///   releases them,
 /// - prunes and releases now-empty PT/PD/PDP pages,
 /// - releases the root PML4 frame itself.
 pub fn destroy_user_address_space(pml4_phys: u64) {
-    // Keep legacy default: do not release USER_CODE PFNs (alias-safe mode).
-    destroy_user_address_space_with_options(pml4_phys, false);
-}
-
-/// Destroys a user address space rooted at `pml4_phys` with explicit code-page policy.
-///
-/// ## What this function does
-/// 1. Temporarily activates `pml4_phys` as the current CR3 (via [`with_address_space`])
-///    so that recursive page-table walk addresses resolve against the correct hierarchy.
-/// 2. Unmaps every page in `[USER_CODE_BASE, USER_CODE_END)` and
-///    `[USER_STACK_BASE, USER_STACK_TOP)`, pruning now-empty PT/PD/PDP frames as it
-///    goes.
-/// 3. Releases the root PML4 frame back to the PMM.
-/// 4. Restores the previous CR3 before returning.
-///
-/// ## What this function does NOT do
-/// - It does not touch any kernel-half mappings (PML4 entries 256 and above). Those
-///   are shared with every other address space and must remain intact.
-/// - It does not handle regions outside `USER_CODE` and `USER_STACK`; any other
-///   user mappings that exist would be silently leaked.
-///
-/// ## Caller constraints
-/// - Must NOT be called with `pml4_phys` equal to the kernel CR3 that has no
-///   corresponding user address space — doing so would unmap the user windows
-///   inside the kernel page tables, corrupting all future user tasks.
-/// - Interrupts are disabled for the duration of the CR3 switch (handled internally
-///   by [`with_address_space`]).
-///
-/// ## `release_user_code_pfns` policy
-/// - `false`: clear user-code mappings but keep mapped code PFNs reserved
-///   (safe for temporary user aliases of kernel text pages).
-/// - `true`: release user-code PFNs back to PMM (required for loader-owned images).
-pub fn destroy_user_address_space_with_options(pml4_phys: u64, release_user_code_pfns: bool) {
-    // Default behavior: tear down full configured user code + stack windows.
     destroy_user_address_space_with_page_counts(
         pml4_phys,
-        release_user_code_pfns,
         (USER_CODE_SIZE / PAGE_SIZE_U64) as usize,
         (USER_STACK_SIZE / PAGE_SIZE_U64) as usize,
     );
@@ -637,16 +609,45 @@ pub fn destroy_user_address_space_with_options(pml4_phys: u64, release_user_code
 
 /// Destroys a user address space with explicit mapped-page counts.
 ///
-/// This variant is intended for callers that know exactly how many pages were
-/// mapped and can therefore avoid scanning full user regions.
+/// ## What this function does
+/// 1. Temporarily activates `pml4_phys` as the current CR3 (via [`with_address_space`])
+///    so that recursive page-table walk addresses resolve against the correct hierarchy.
+/// 2. Unmaps every mapped page in the known `USER_CODE`, `USER_STACK`, and
+///    `USER_HEAP` windows, pruning now-empty PT/PD/PDP frames as it goes.
+/// 3. Scans the remainder of the user PML4 slot range
+///    (`[USER_CODE_BASE, USER_ADDRESS_SPACE_SCAN_END)`) for any other present
+///    mapping and reclaims it too, so a region outside those three fixed
+///    windows (e.g. a future per-process `mmap` allocation) cannot be
+///    silently leaked.
+/// 4. Releases the root PML4 frame back to the PMM.
+/// 5. Restores the previous CR3 before returning.
+///
+/// Every leaf frame unmapped along the way goes through
+/// `PhysicalMemoryManager::release_pfn`, which is refcounted: a frame with
+/// more than one owner (bumped via `inc_refcount` at the site that created
+/// the extra mapping — e.g. a code page deliberately aliased over another
+/// mapping) merely has its count decremented here and stays allocated until
+/// its other owner(s) release it too. This is what replaced the old
+/// `release_user_code_pfns` boolean policy: callers no longer choose whether
+/// to release a window's frames — the refcount always decides.
 ///
 /// `stack_page_count_from_top` is interpreted as a contiguous window growing
 /// downward from [`USER_STACK_TOP`], matching how user stacks are allocated.
-///
 /// Count values are clamped to configured region capacities.
+///
+/// ## What this function does NOT do
+/// - It does not touch any kernel-half mappings (PML4 entries 256 and above), nor
+///   PML4 slot 0 (the low-memory identity map). Those are shared with every other
+///   address space and must remain intact; see [`USER_ADDRESS_SPACE_SCAN_END`].
+///
+/// ## Caller constraints
+/// - Must NOT be called with `pml4_phys` equal to the kernel CR3 that has no
+///   corresponding user address space — doing so would unmap the user windows
+///   inside the kernel page tables, corrupting all future user tasks.
+/// - Interrupts are disabled for the duration of the CR3 switch (handled internally
+///   by [`with_address_space`]).
 pub fn destroy_user_address_space_with_page_counts(
     pml4_phys: u64,
-    release_user_code_pfns: bool,
     code_page_count: usize,
     stack_page_count_from_top: usize,
 ) {
@@ -667,16 +668,16 @@ pub fn destroy_user_address_space_with_page_counts(
     // Teardown must run while the target CR3 is active so recursive-table
     // helper addresses resolve to the correct hierarchy.
     with_address_space(pml4_phys, || {
-        // Step 1: Drop user-code mappings for the known mapped prefix.
-        // Caller controls whether mapped code PFNs are returned to PMM.
+        // Step 1: Drop user-code mappings for the known mapped prefix. The refcounted
+        // `release_pfn` decides whether a code frame is actually freed here or merely
+        // has its count decremented (when another mapping still owns it).
         let mut va = USER_CODE_BASE;
         for _ in 0..code_pages {
-            unmap_page_and_prune_pagetable_hierarchy(va, release_user_code_pfns);
+            unmap_page_and_prune_pagetable_hierarchy(va, true);
             va += PAGE_SIZE_U64;
         }
 
         // Step 2: Drop mapped user-stack pages in the top-down stack window.
-        // Stack pages are always process-owned, so leaf PFNs are always released.
         let mut stack_va = USER_STACK_TOP - (stack_pages as u64 * PAGE_SIZE_U64);
         while stack_va < USER_STACK_TOP {
             unmap_page_and_prune_pagetable_hierarchy(stack_va, true);
@@ -685,6 +686,13 @@ pub fn destroy_user_address_space_with_page_counts(
 
         // Step 3: Clear and release all mapped pages in the user-mode heap region.
         unmap_user_heap_region();
+
+        // Step 4: Catch-all — reclaim any other present user mapping outside the
+        // three windows above (e.g. a future mmap-created region). Code/Stack/Heap
+        // were already cleared, so in the common case this scan finds nothing left
+        // and is a cheap no-op; it exists so nothing in the user PML4 slot range can
+        // be silently leaked at teardown.
+        reclaim_user_range(USER_CODE_BASE, USER_ADDRESS_SPACE_SCAN_END);
     });
 
     // Finally release the root PML4 frame itself after its hierarchy has been pruned.
@@ -705,8 +713,26 @@ pub fn destroy_user_address_space_with_page_counts(
 /// This traverses intermediate page table directories to efficiently skip
 /// unmapped sub-regions and prunes hierarchy frames as they become empty.
 pub fn unmap_user_heap_region() {
-    let mut va = USER_HEAP_BASE;
-    while va < USER_HEAP_END {
+    reclaim_user_range(USER_HEAP_BASE, USER_HEAP_END);
+}
+
+/// Reclaims every present user leaf mapping in `[scan_start, scan_end)`.
+///
+/// Walks the 4-level page-table hierarchy, skipping non-present sub-trees at
+/// the largest granularity possible (512 GiB / 1 GiB / 2 MiB jumps) so large
+/// unmapped gaps are cheap to pass over, and releases each present leaf frame
+/// via the refcounted `PhysicalMemoryManager::release_pfn` while pruning
+/// now-empty PT/PD/PDP levels — the same technique `unmap_user_heap_region`
+/// has always used for the heap window, generalized to arbitrary bounds.
+///
+/// Callers must ensure the target address space is already active (e.g. via
+/// [`with_address_space`]) so recursive-mapping helper addresses resolve
+/// correctly, and must only pass bounds known not to overlap
+/// address-space-shared infrastructure (PML4 slot 0's identity map, or the
+/// higher-half kernel slots) — see [`USER_ADDRESS_SPACE_SCAN_END`].
+fn reclaim_user_range(scan_start: u64, scan_end: u64) {
+    let mut va = scan_start;
+    while va < scan_end {
         // Step 1: Resolve PML4 level and skip if non-present.
         let pml4 = table_at(PML4_TABLE_ADDR);
         let pml4_idx = pml4_index(va);

--- a/main64/kernel/src/memory/vmm/mod.rs
+++ b/main64/kernel/src/memory/vmm/mod.rs
@@ -45,10 +45,10 @@ pub use diagnostics::{
 #[allow(unused_imports)]
 pub use mapping::{
     clone_kernel_pml4_for_user, configure_wc_mapping, destroy_user_address_space,
-    destroy_user_address_space_with_options, destroy_user_address_space_with_page_counts,
-    map_user_page, map_virtual_to_physical, map_virtual_to_physical_uc, map_virtual_to_physical_wc,
-    populate_page_table_path, switch_page_directory, try_map_virtual_to_physical,
-    unmap_user_heap_region, unmap_virtual_address, with_address_space, MapError,
+    destroy_user_address_space_with_page_counts, map_user_page, map_virtual_to_physical,
+    map_virtual_to_physical_uc, map_virtual_to_physical_wc, populate_page_table_path,
+    switch_page_directory, try_map_virtual_to_physical, unmap_user_heap_region,
+    unmap_virtual_address, unmap_without_release, with_address_space, MapError,
 };
 #[allow(unused_imports)]
 pub use page_fault::{

--- a/main64/kernel/src/memory/vmm/vmm_constants.rs
+++ b/main64/kernel/src/memory/vmm/vmm_constants.rs
@@ -32,3 +32,17 @@ pub const USER_HEAP_SIZE: u64 = 0x0000_0000_1000_0000;
 
 /// User heap end address (exclusive).
 pub const USER_HEAP_END: u64 = USER_HEAP_BASE + USER_HEAP_SIZE;
+
+/// Exclusive upper bound of the canonical "low half" of the virtual address
+/// space that per-task user mappings (Code/Stack/Heap and any future
+/// mmap-created regions) live in.
+///
+/// `USER_CODE_BASE` through this bound covers exactly the PML4 slots used for
+/// user mappings (currently slots 224-255) and deliberately excludes PML4
+/// slot 0 (the low-memory identity map, shared by every address space) and
+/// the higher-half kernel slots (256 and above, also shared). A full-range
+/// scan bounded by `[USER_CODE_BASE, USER_ADDRESS_SPACE_SCAN_END)` can
+/// therefore safely reclaim *any* present user leaf mapping — including ones
+/// outside the fixed Code/Stack/Heap windows — without risking a scan into
+/// address-space-shared infrastructure.
+pub const USER_ADDRESS_SPACE_SCAN_END: u64 = 0x0000_8000_0000_0000;

--- a/main64/kernel/src/process/loader.rs
+++ b/main64/kernel/src/process/loader.rs
@@ -368,17 +368,17 @@ fn release_allocated_code_pfns(mgr: &mut pmm::PhysicalMemoryManager, code_pfns: 
 
 /// Best-effort rollback for partially created user mappings.
 ///
-/// Uses the same explicit owned-code teardown policy as normal process exit and
-/// then releases only frames that were allocated but never mapped.
+/// Uses the same teardown path as normal process exit (which always releases
+/// mapped leaf frames back to PMM via the refcounted `release_pfn`) and then
+/// releases only frames that were allocated but never mapped.
 fn cleanup_failed_program_mapping(user_cr3: u64, state: &MapState) {
-    // Teardown only the mapped ranges with owned-code policy:
+    // Teardown only the mapped ranges:
     // - `mapped_code_pages` tracks successful code-leaf mappings,
     // - stack teardown only runs when bootstrap page mapping succeeded,
     // - page-table hierarchy + CR3 root are released afterwards by VMM.
     let stack_pages_mapped = if state.stack_mapped { 1 } else { 0 };
     vmm::destroy_user_address_space_with_page_counts(
         user_cr3,
-        true,
         state.mapped_code_pages,
         stack_pages_mapped,
     );
@@ -422,12 +422,7 @@ fn spawn_loaded_program(loaded: LoadedProgram) -> ExecResult<usize> {
             );
             // Spawn failed before task activation, so only loader-mapped pages
             // exist (code prefix + single bootstrap stack page).
-            vmm::destroy_user_address_space_with_page_counts(
-                loaded.cr3,
-                true,
-                loaded.code_page_count,
-                1,
-            );
+            vmm::destroy_user_address_space_with_page_counts(loaded.cr3, loaded.code_page_count, 1);
             Err(ExecError::SpawnFailed)
         }
     }

--- a/main64/kernel/src/scheduler/roundrobin/manager.rs
+++ b/main64/kernel/src/scheduler/roundrobin/manager.rs
@@ -87,15 +87,12 @@ pub(crate) fn remove_task(
     // Step 3: precompute address-space teardown intent.
     // Kernel tasks carry no user CR3, so no address-space cleanup is needed.
     let mut cleanup = if meta.slots[task_id].is_user {
-        Some((
-            meta.slots[task_id].cr3,
-            meta.slots[task_id].release_user_code_pfns,
-        ))
+        Some(meta.slots[task_id].cr3)
     } else {
         None
     };
 
-    if let Some((cr3, _)) = cleanup {
+    if let Some(cr3) = cleanup {
         if active_cr3_value() == cr3 {
             let kernel_cr3 = kernel_cr3_value();
 
@@ -226,10 +223,9 @@ pub(crate) fn remove_task(
     // Final step: push user address-space for deferred cleanup.
     // Releasing the address space is a slow operation that must happen outside
     // the scheduler lock.
-    if let Some((cr3, release_user_code_pfns)) = cleanup {
+    if let Some(cr3) = cleanup {
         if meta.pending_free_address_spaces.try_reserve(1).is_ok() {
-            meta.pending_free_address_spaces
-                .push((cr3, release_user_code_pfns));
+            meta.pending_free_address_spaces.push(cr3);
         }
     }
 
@@ -545,15 +541,13 @@ pub(crate) fn free_pending_stacks(stacks: &[(*mut u8, usize)]) {
 }
 
 /// Drains `pending_free_address_spaces` for deallocation.
-pub(crate) fn take_pending_address_spaces_for_free(
-    meta: &mut SchedulerMetadata,
-) -> Vec<(u64, bool)> {
+pub(crate) fn take_pending_address_spaces_for_free(meta: &mut SchedulerMetadata) -> Vec<u64> {
     core::mem::take(&mut meta.pending_free_address_spaces)
 }
 
 /// Frees pending address spaces outside the scheduler lock.
-pub(crate) fn free_pending_address_spaces(address_spaces: &[(u64, bool)]) {
-    for &(cr3, release_user_code_pfns) in address_spaces {
-        vmm::destroy_user_address_space_with_options(cr3, release_user_code_pfns);
+pub(crate) fn free_pending_address_spaces(address_spaces: &[u64]) {
+    for &cr3 in address_spaces {
+        vmm::destroy_user_address_space(cr3);
     }
 }

--- a/main64/kernel/src/scheduler/roundrobin/mod.rs
+++ b/main64/kernel/src/scheduler/roundrobin/mod.rs
@@ -328,7 +328,7 @@ pub fn on_timer_tick(current_frame: *mut SavedRegisters) -> *mut SavedRegisters 
     // (`!meta.started`) returns before this binding is ever used or dropped.
     #[cfg_attr(not(debug_assertions), allow(unused_mut))]
     let mut stacks_to_free: Vec<(*mut u8, usize)>;
-    let address_spaces_to_free: Vec<(u64, bool)>;
+    let address_spaces_to_free: Vec<u64>;
     let removed_zombie_tasks: bool;
 
     let result = {

--- a/main64/kernel/src/scheduler/roundrobin/spawn.rs
+++ b/main64/kernel/src/scheduler/roundrobin/spawn.rs
@@ -26,14 +26,24 @@ pub fn spawn_user_task(entry_rip: u64, user_rsp: u64, cr3: u64) -> Result<usize,
         entry_rip,
         user_rsp,
         cr3,
-        release_user_code_pfns: false,
     })
 }
 
 /// Creates a new user task that owns dedicated user-code pages.
 ///
 /// Use this for loader-backed binaries that were copied into private PMM
-/// frames. On task teardown these code PFNs are released.
+/// frames.
+///
+/// Historically this differed from [`spawn_user_task`] in whether task
+/// teardown released the mapped user-code PFNs back to PMM (a manual
+/// `release_user_code_pfns` boolean policy). That policy was replaced by
+/// PMM-level frame refcounting (see `memory::pmm::manager::inc_refcount` /
+/// `release_pfn`): teardown now always calls the refcounted `release_pfn` for
+/// every mapped code leaf, and a frame that is genuinely shared with another
+/// mapping (bumped via `inc_refcount` at the site that created the alias)
+/// simply survives until its other owner releases it too. Both spawn
+/// functions are therefore equivalent today; both are kept as named entry
+/// points for call-site clarity (loader-owned vs. ad-hoc/test task images).
 pub fn spawn_user_task_owning_code(
     entry_rip: u64,
     user_rsp: u64,
@@ -43,7 +53,6 @@ pub fn spawn_user_task_owning_code(
         entry_rip,
         user_rsp,
         cr3,
-        release_user_code_pfns: true,
     })
 }
 
@@ -118,29 +127,20 @@ fn spawn_internal(kind: SpawnKind) -> Result<usize, SpawnError> {
             .try_reserve(1)
             .map_err(|_| SpawnError::StackAllocationFailed)?;
 
-        let (frame_ptr, cr3, user_rsp, kernel_rsp_top, is_user, release_user_code_pfns) = match kind
-        {
+        let (frame_ptr, cr3, user_rsp, kernel_rsp_top, is_user) = match kind {
             SpawnKind::Kernel { entry } => {
                 let (frame_ptr, kernel_rsp_top) =
                     build_initial_kernel_task_frame(stack_ptr, TASK_STACK_SIZE, entry);
-                (frame_ptr, 0, 0, kernel_rsp_top, false, false)
+                (frame_ptr, 0, 0, kernel_rsp_top, false)
             }
             SpawnKind::User {
                 entry_rip,
                 user_rsp,
                 cr3,
-                release_user_code_pfns,
             } => {
                 let (frame_ptr, kernel_rsp_top) =
                     build_initial_user_task_frame(stack_ptr, TASK_STACK_SIZE, entry_rip, user_rsp);
-                (
-                    frame_ptr,
-                    cr3,
-                    user_rsp,
-                    kernel_rsp_top,
-                    true,
-                    release_user_code_pfns,
-                )
+                (frame_ptr, cr3, user_rsp, kernel_rsp_top, true)
             }
         };
 
@@ -160,7 +160,6 @@ fn spawn_internal(kind: SpawnKind) -> Result<usize, SpawnError> {
             user_heap_top: if is_user { vmm::USER_HEAP_BASE } else { 0 },
             kernel_rsp_top,
             is_user,
-            release_user_code_pfns,
             stack_base: stack_ptr,
             stack_size: TASK_STACK_SIZE,
             fpu_state: fpu_ptr,

--- a/main64/kernel/src/scheduler/roundrobin/types.rs
+++ b/main64/kernel/src/scheduler/roundrobin/types.rs
@@ -34,11 +34,6 @@ pub enum SpawnKind {
         user_rsp: u64,
         /// Address-space root (CR3 physical address) associated with task.
         cr3: u64,
-        /// Whether user-code PFNs should be released on task teardown.
-        ///
-        /// `false` is used for temporary user aliases of kernel code pages.
-        /// `true` is used for loader-owned binaries with dedicated code PFNs.
-        release_user_code_pfns: bool,
     },
 }
 
@@ -160,12 +155,6 @@ pub struct TaskEntry {
     /// When set, scheduler updates `TSS.RSP0` from `kernel_rsp_top`.
     pub is_user: bool,
 
-    /// Code-page teardown policy for user tasks.
-    ///
-    /// `true` means user-code leaf PFNs are returned to PMM when the task CR3
-    /// is destroyed. `false` keeps code PFNs reserved (alias-safe).
-    pub release_user_code_pfns: bool,
-
     /// Base address of this task's heap-allocated kernel stack.
     pub stack_base: *mut u8,
 
@@ -197,7 +186,6 @@ impl TaskEntry {
             user_heap_top: 0,
             kernel_rsp_top: 0,
             is_user: false,
-            release_user_code_pfns: false,
             stack_base: ptr::null_mut(),
             stack_size: 0,
             fpu_state: ptr::null_mut(),
@@ -276,12 +264,13 @@ pub struct SchedulerMetadata {
     /// Drained via `core::mem::take` inside the scheduler lock.
     pub pending_free_stacks: Vec<(*mut u8, usize)>,
 
-    /// Address spaces from terminated user tasks awaiting deallocation.
+    /// Address spaces (CR3 roots) from terminated user tasks awaiting
+    /// deallocation.
     ///
     /// Destroying an address space is a slow operation that traverses page
     /// tables and modifies PMM structures. It must happen outside the scheduler
     /// spinlock to keep interrupt latency low.
-    pub pending_free_address_spaces: Vec<(u64, bool)>,
+    pub pending_free_address_spaces: Vec<u64>,
 
     /// Slot index of the task whose FPU/SSE state is currently live in the
     /// CPU's XMM/x87 registers.

--- a/main64/kernel/tests/console_flush_lock_test.rs
+++ b/main64/kernel/tests/console_flush_lock_test.rs
@@ -173,7 +173,7 @@ fn test_scroll_triggered_flush_runs_with_interrupts_enabled() {
              has interrupts disabled"
         );
         assert!(
-            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            vram.contains(&WHITE_RGB),
             "the flush must have actually copied rendered glyph pixels into \
              the (fake) physical framebuffer, not merely been recorded as a \
              no-op"
@@ -223,7 +223,7 @@ fn test_flush_does_not_force_enable_interrupts_when_caller_had_them_disabled() {
              deferred flush when the caller already had them disabled"
         );
         assert!(
-            vram.iter().any(|&pixel| pixel == WHITE_RGB),
+            vram.contains(&WHITE_RGB),
             "the flush must still have applied even though interrupts were \
              disabled throughout"
         );

--- a/main64/kernel/tests/heap_test.rs
+++ b/main64/kernel/tests/heap_test.rs
@@ -322,10 +322,10 @@ fn test_small_allocations_round_trip_through_free_list() {
     let layout = Layout::from_size_align(1, 8).unwrap();
 
     // Step 1: Allocate many 1-byte payloads.
-    for i in 0..COUNT {
+    for (i, slot) in ptrs.iter_mut().enumerate() {
         let p = test_heap.allocate(layout);
         assert!(!p.is_null(), "allocation {} should succeed", i);
-        ptrs[i] = p;
+        *slot = p;
     }
 
     // Step 2: Free every other block.  Because the retained blocks stay in use,

--- a/main64/kernel/tests/pmm_test.rs
+++ b/main64/kernel/tests/pmm_test.rs
@@ -287,3 +287,138 @@ fn test_pmm_physical_address_calculation() {
         assert!(pmm.release_pfn(frame.pfn));
     });
 }
+
+/// Test that a single-owner (refcount == 1) frame is freed on exactly one
+/// `release_pfn` call — the pre-existing allocator behavior must be
+/// unaffected by the addition of per-frame refcounting.
+/// Contract: pmm single owner frame freed after one release.
+/// Given: A freshly allocated frame with no additional owners (refcount == 1).
+/// When: `release_pfn` is called exactly once.
+/// Then: The frame is returned to the free pool immediately, and a second
+///       `release_pfn` call on the same PFN fails (already free).
+/// Failure Impact: Regressing single-owner semantics would either leak every
+///        frame in the kernel (never actually freed) or double-free on the
+///        very first release call. Release-blocking.
+#[test_case]
+fn test_pmm_single_owner_frame_freed_after_one_release() {
+    pmm::with_pmm(|mgr| {
+        let free_before = mgr.total_free_frames();
+
+        let frame = mgr.alloc_frame().expect("allocation should succeed");
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before - 1,
+            "allocating a frame must reduce the free count by exactly one"
+        );
+
+        assert!(
+            mgr.release_pfn(frame.pfn),
+            "releasing a single-owner frame must succeed"
+        );
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before,
+            "a single-owner frame must be fully freed after exactly one release_pfn call"
+        );
+
+        assert!(
+            !mgr.release_pfn(frame.pfn),
+            "releasing an already-free frame a second time must fail"
+        );
+    });
+}
+
+/// Test that a frame with an extra owner (refcount == 2, via `inc_refcount`)
+/// survives one `release_pfn` call and is only actually freed — and therefore
+/// only re-allocatable — after the second `release_pfn` call.
+///
+/// This is the core new behavior the PMM frame-refcounting mechanism
+/// introduces: it replaces the old manual boolean "does this caller own the
+/// frame" policy with an accurate reference count, so a frame shared between
+/// two owners (e.g. user-code aliased over another mapping) is never freed
+/// while any owner still holds it, and is freed exactly once when the last
+/// owner releases it.
+/// Contract: pmm refcounted frame survives until last release.
+/// Given: A frame allocated normally (refcount == 1), then shared with a
+///        second owner via `inc_refcount` (refcount == 2).
+/// When: `release_pfn` is called twice.
+/// Then: The first call succeeds but leaves the frame allocated (free count
+///       unchanged); the second call actually frees it (free count restored).
+/// Failure Impact: A regression here would either free a still-shared frame
+///        too early (double-use-after-free of physical memory across two
+///        live mappings) or leak a frame forever once shared. Release-blocking.
+#[test_case]
+fn test_pmm_refcounted_frame_survives_until_last_release() {
+    pmm::with_pmm(|mgr| {
+        let free_before = mgr.total_free_frames();
+
+        let frame = mgr.alloc_frame().expect("allocation should succeed");
+        assert_eq!(mgr.total_free_frames(), free_before - 1);
+
+        // Simulate a second owner aliasing this already-allocated frame.
+        assert!(
+            mgr.inc_refcount(frame.pfn),
+            "inc_refcount must succeed on an allocated frame"
+        );
+
+        // First release: one owner (the second one) remains, so the frame
+        // must stay allocated — the free count must not change.
+        assert!(
+            mgr.release_pfn(frame.pfn),
+            "first release of a shared frame must succeed"
+        );
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before - 1,
+            "a frame with a remaining owner must stay allocated after one release"
+        );
+
+        // Second release: last owner releases it, so the frame is now
+        // actually freed and the free count is restored.
+        assert!(
+            mgr.release_pfn(frame.pfn),
+            "second (final) release of a shared frame must succeed"
+        );
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before,
+            "a shared frame must be freed once its last owner releases it"
+        );
+
+        // A third release on the now-free frame must fail.
+        assert!(
+            !mgr.release_pfn(frame.pfn),
+            "releasing an already-free frame must fail"
+        );
+    });
+}
+
+/// Test that `inc_refcount` rejects a PFN that is not currently allocated,
+/// both for a genuinely free frame and for a PFN outside every known region.
+/// Contract: pmm inc refcount rejects unallocated or out of range pfn.
+/// Given: A frame that was allocated and then fully released (free again),
+///        and a PFN far outside any configured PMM region.
+/// When: `inc_refcount` is called on each.
+/// Then: Both calls return `false` — incrementing the refcount of a frame the
+///       allocator does not consider allocated must never silently succeed
+///       (it would create a phantom extra owner that can never be balanced).
+/// Failure Impact: Silently accepting this would let a caller create a
+///        reference to memory that isn't actually reserved by the allocator,
+///        an invisible corruption/double-allocation hazard. Release-blocking.
+#[test_case]
+fn test_pmm_inc_refcount_rejects_unallocated_or_out_of_range_pfn() {
+    pmm::with_pmm(|mgr| {
+        let frame = mgr.alloc_frame().expect("allocation should succeed");
+        assert!(mgr.release_pfn(frame.pfn), "initial release must succeed");
+
+        assert!(
+            !mgr.inc_refcount(frame.pfn),
+            "inc_refcount must reject a PFN that is currently free"
+        );
+
+        assert!(
+            !mgr.inc_refcount(u64::MAX / 2),
+            "inc_refcount must reject a PFN outside every known region"
+        );
+    });
+}

--- a/main64/kernel/tests/pmm_uefi_test.rs
+++ b/main64/kernel/tests/pmm_uefi_test.rs
@@ -158,6 +158,43 @@ const META_REGION_FRAMES: u64 = META_REGION_SIZE / PAGE_SIZE; // 64
 /// Frames the low `[KERNEL_OFFSET, STACK_TOP)` reservation occupies inside the main region.
 const LOW_RESERVED_FRAMES: u64 = (STACK_TOP - KERNEL_OFFSET) / PAGE_SIZE; // 768
 
+/// Rounds `x` up to the next multiple of 8 — mirrors `pmm::align_up(x, 8)`,
+/// reimplemented here as a `const fn` so it can be used in `const` contexts.
+const fn align_up8(x: u64) -> u64 {
+    (x + 7) & !7
+}
+
+/// Bitmap size for a region with `frames` frames: 1 bit/frame, aligned to 8
+/// bytes — mirrors the `bitmap_bytes` computation in
+/// `PhysicalMemoryManager::new()`.
+const fn bitmap_bytes_for(frames: u64) -> u64 {
+    align_up8(frames.div_ceil(8))
+}
+
+/// Refcount-array size for a region with `frames` frames: 1 byte/frame,
+/// aligned to 8 bytes — mirrors the `refcount_bytes` computation in
+/// `PhysicalMemoryManager::new()`.
+const fn refcount_bytes_for(frames: u64) -> u64 {
+    align_up8(frames)
+}
+
+/// Total PMM metadata size for this synthetic 2-region layout: header +
+/// region array + both regions' bitmaps + both regions' refcount arrays, in
+/// the same order `PhysicalMemoryManager::new()` lays them out. Computed from
+/// the real struct sizes so this test does not drift if either struct's
+/// layout changes.
+const METADATA_TOTAL_BYTES: u64 = core::mem::size_of::<pmm::PmmLayoutHeader>() as u64
+    + 2 * core::mem::size_of::<pmm::PmmRegion>() as u64
+    + bitmap_bytes_for(MAIN_REGION_FRAMES)
+    + bitmap_bytes_for(META_REGION_FRAMES)
+    + refcount_bytes_for(MAIN_REGION_FRAMES)
+    + refcount_bytes_for(META_REGION_FRAMES);
+
+/// Number of 4 KiB pages the metadata occupies inside region 1 (the
+/// metadata-backing region). `regions[1].frames_free` is reduced by exactly
+/// this many frames after `pmm::init`.
+const METADATA_RESERVED_PAGES: u64 = METADATA_TOTAL_BYTES.div_ceil(PAGE_SIZE);
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -206,7 +243,8 @@ fn test_synthetic_uefi_regions_parsed() {
 /// Given: the parsed synthetic map.
 /// When: inspecting `frames_free` right after init.
 /// Then: region 0 has exactly `LOW_RESERVED_FRAMES` used (the `[KERNEL_OFFSET, STACK_TOP)`
-///       block) and everything else free; region 1 has exactly one page used (the metadata).
+///       block) and everything else free; region 1 has exactly `METADATA_RESERVED_PAGES` used
+///       (the metadata: header + region array + both bitmaps + both refcount arrays).
 ///       This proves the bitmaps were zeroed (no stray used bits) AND that the reservation is
 ///       two separate ranges, not one giant span swallowing the gap between them.
 /// Failure Impact: a single-span reservation (the pre-rework bug) would mark almost all RAM
@@ -225,12 +263,13 @@ fn test_synthetic_uefi_two_reserved_ranges() {
             "region 0: only [KERNEL_OFFSET, STACK_TOP) reserved, gap above stays free"
         );
 
-        // Region 1: only the metadata itself (header + regions + bitmaps, < 4 KiB here)
-        // is reserved — exactly one page — leaving the rest of the region free.
+        // Region 1: only the metadata itself (header + regions + bitmaps + refcount
+        // arrays) is reserved — exactly `METADATA_RESERVED_PAGES` pages — leaving the
+        // rest of the region free.
         assert_eq!(
             regions[1].frames_free,
-            META_REGION_FRAMES - 1,
-            "region 1: only the one metadata page is reserved"
+            META_REGION_FRAMES - METADATA_RESERVED_PAGES,
+            "region 1: only the metadata pages are reserved"
         );
     });
 }
@@ -268,8 +307,8 @@ fn test_synthetic_uefi_first_alloc_skips_reserved() {
             "allocated frame must not be in the low reserved block"
         );
         assert!(
-            !(meta_addr..meta_addr + PAGE_SIZE).contains(&addr),
-            "allocated frame must not be in the reserved metadata page"
+            !(meta_addr..meta_addr + METADATA_RESERVED_PAGES * PAGE_SIZE).contains(&addr),
+            "allocated frame must not be in the reserved metadata pages"
         );
 
         // Do NOT dereference: the synthetic frame address is not backed by real RAM.

--- a/main64/kernel/tests/serial_deadlock_test.rs
+++ b/main64/kernel/tests/serial_deadlock_test.rs
@@ -41,7 +41,7 @@ impl fmt::Display for FaultingFormatter {
         // Trigger a #PF by reading from a non-present address.
         // We use address 0x0 which is not mapped in the kernel.
         unsafe {
-            let _ = core::ptr::read_volatile(0x0 as *const u8);
+            let _ = core::ptr::read_volatile(core::ptr::null::<u8>());
         }
         Ok(())
     }

--- a/main64/kernel/tests/syscall_dispatch_test.rs
+++ b/main64/kernel/tests/syscall_dispatch_test.rs
@@ -769,7 +769,7 @@ fn test_writable_user_buffer_rejects_read_only_page_after_boundary() {
         "a range crossing into a read-only page must be rejected"
     );
 
-    let ret = syscall::dispatch(SyscallId::GetTime as u64, (first_va + 128) as u64, 0, 0, 0);
+    let ret = syscall::dispatch(SyscallId::GetTime as u64, first_va + 128, 0, 0, 0);
     assert_eq!(
         ret,
         syscall::SYSCALL_OK,

--- a/main64/kernel/tests/time_test.rs
+++ b/main64/kernel/tests/time_test.rs
@@ -77,7 +77,7 @@ fn test_calibrate_tsc_returns_plausible_value() {
         "calibrated TSC frequency must be positive"
     );
     assert!(
-        ticks_per_us >= 10 && ticks_per_us <= 20_000,
+        (10..=20_000).contains(&ticks_per_us),
         "calibrated TSC frequency {} is outside plausible CPU range",
         ticks_per_us
     );

--- a/main64/kernel/tests/vmm_test.rs
+++ b/main64/kernel/tests/vmm_test.rs
@@ -470,13 +470,18 @@ fn test_destroy_user_address_space_releases_user_leaf_and_table_frames() {
     });
 }
 
-/// Contract: destroy user address space does not release code leaf frame.
+/// Contract: destroy user address space releases a single-owner code leaf frame.
+///
+/// Refcounting replaced the old `release_user_code_pfns` boolean policy: a
+/// code frame with exactly one owner (the common case — a loader-owned
+/// binary's private code frame) is now always released by
+/// `destroy_user_address_space`, regardless of which region it is mapped in.
 /// Given: The subsystem is initialized with the explicit preconditions in this test body, including any literal addresses, vectors, sizes, flags, and constants used below.
 /// When: The exact operation sequence in this function is executed against that state.
-/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space does not release code leaf frame".
+/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space releases a single-owner code leaf frame".
 /// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
 #[test_case]
-fn test_destroy_user_address_space_does_not_release_code_leaf_frame() {
+fn test_destroy_user_address_space_releases_single_owner_code_leaf_frame() {
     const TEST_CODE_VA: u64 = vmm::USER_CODE_BASE;
 
     let user_cr3 = vmm::clone_kernel_pml4_for_user();
@@ -491,43 +496,71 @@ fn test_destroy_user_address_space_does_not_release_code_leaf_frame() {
 
     pmm::with_pmm(|mgr| {
         assert!(
-            mgr.release_pfn(code_leaf.pfn),
-            "code-leaf PFN should remain allocated after destroy and require explicit release"
+            !mgr.release_pfn(code_leaf.pfn),
+            "single-owner code-leaf PFN should already be free after address-space destroy"
         );
     });
 }
 
-/// Contract: destroy user address space with owned-code policy releases code leaf frame.
+/// Contract: destroy user address space keeps a shared (refcounted) code leaf frame
+/// allocated until its other owner also releases it.
+///
+/// This is the core new behavior this refactor introduces: instead of a
+/// caller-chosen boolean policy, a frame that is deliberately aliased into a
+/// second mapping (via `inc_refcount`, mirroring e.g. a user-code window
+/// pointing at a frame another mapping still references) survives address
+/// -space teardown and is only actually freed once every owner has released
+/// it.
 /// Given: The subsystem is initialized with the explicit preconditions in this test body, including any literal addresses, vectors, sizes, flags, and constants used below.
 /// When: The exact operation sequence in this function is executed against that state.
-/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space with owned-code policy releases code leaf frame".
+/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space keeps a shared code leaf frame allocated until its other owner also releases it".
 /// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
 #[test_case]
-fn test_destroy_user_address_space_with_options_releases_code_leaf_frame() {
+fn test_destroy_user_address_space_keeps_shared_code_leaf_frame_until_last_release() {
     const TEST_CODE_VA: u64 = vmm::USER_CODE_BASE;
+    const OUTER_ALIAS_VA: u64 = 0xFFFF_8098_789A_B000;
 
     let user_cr3 = vmm::clone_kernel_pml4_for_user();
     let code_leaf = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("code frame allocation failed"));
+
+    // Create a second, independent owner of the same physical frame: map it
+    // into the currently active (kernel) address space at a scratch VA, and
+    // record the extra ownership in PMM via `inc_refcount`.
+    vmm::unmap_virtual_address(OUTER_ALIAS_VA);
+    vmm::map_virtual_to_physical(OUTER_ALIAS_VA, code_leaf.physical_address());
+    assert!(
+        pmm::with_pmm(|mgr| mgr.inc_refcount(code_leaf.pfn)),
+        "inc_refcount must succeed on an allocated frame"
+    );
 
     vmm::with_address_space(user_cr3, || {
         vmm::map_user_page(TEST_CODE_VA, code_leaf.pfn, false)
             .expect("test code VA should map in cloned address space");
     });
 
-    vmm::destroy_user_address_space_with_options(user_cr3, true);
+    // Destroying the user address space releases only the user-side mapping's
+    // ownership; the outer alias still owns the frame, so it must survive.
+    vmm::destroy_user_address_space(user_cr3);
 
     pmm::with_pmm(|mgr| {
         assert!(
-            !mgr.release_pfn(code_leaf.pfn),
-            "owned-code policy must release code-leaf PFN during address-space destroy"
+            mgr.release_pfn(code_leaf.pfn),
+            "shared code-leaf PFN must still be allocated (and thus releasable) \
+             immediately after destroy, because the outer alias still owns it"
         );
     });
+
+    // The explicit `release_pfn` above just consumed the outer alias's
+    // ownership (the last one), so the frame is now actually free.
+    // Clean up the outer alias's page-table mapping too (best effort; the PFN
+    // itself is already released).
+    vmm::unmap_without_release(OUTER_ALIAS_VA);
 }
 
-/// Contract: destroy user address space with page counts tears down only mapped code/stack pages.
+/// Contract: destroy user address space with page counts releases mapped code/stack pages.
 /// Given: The subsystem is initialized with the explicit preconditions in this test body, including any literal addresses, vectors, sizes, flags, and constants used below.
 /// When: The exact operation sequence in this function is executed against that state.
-/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space with page counts tears down only mapped code/stack pages".
+/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space with page counts releases mapped code/stack pages".
 /// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
 #[test_case]
 fn test_destroy_user_address_space_with_page_counts_releases_mapped_code_and_stack_leaf_frames() {
@@ -547,7 +580,7 @@ fn test_destroy_user_address_space_with_page_counts_releases_mapped_code_and_sta
 
     // Exactly one mapped code page at USER_CODE_BASE and one mapped stack page
     // at USER_STACK_TOP-4KiB should be torn down.
-    vmm::destroy_user_address_space_with_page_counts(user_cr3, true, 1, 1);
+    vmm::destroy_user_address_space_with_page_counts(user_cr3, 1, 1);
 
     pmm::with_pmm(|mgr| {
         assert!(
@@ -561,6 +594,50 @@ fn test_destroy_user_address_space_with_page_counts_releases_mapped_code_and_sta
         assert!(
             !mgr.release_pfn(user_cr3 / pmm::PAGE_SIZE),
             "count-based destroy must release user CR3 root PFN"
+        );
+    });
+}
+
+/// Contract: destroy user address space reclaims mappings outside the fixed
+/// Code/Stack/Heap windows (e.g. a future `mmap`-created region).
+///
+/// This exercises the generic catch-all reclaim pass `destroy_user_address_space`
+/// runs after tearing down the three named windows: any VA still present in
+/// the user PML4 slot range gets unmapped and its leaf frame released too, so
+/// a region outside those three windows cannot be silently leaked at teardown.
+/// Given: The subsystem is initialized with the explicit preconditions in this test body, including any literal addresses, vectors, sizes, flags, and constants used below.
+/// When: The exact operation sequence in this function is executed against that state.
+/// Then: All assertions must hold for the checked values and state transitions, preserving the contract "destroy user address space reclaims mappings outside the fixed Code/Stack/Heap windows".
+/// Failure Impact: Indicates a regression in subsystem behavior, ABI/layout, synchronization, or lifecycle semantics and should be treated as release-blocking until understood.
+#[test_case]
+fn test_destroy_user_address_space_reclaims_mapping_outside_known_regions() {
+    // Just above the heap window, well below the stack guard page: not Code,
+    // not Stack/Guard, not Heap — i.e. classify_user_region returns None.
+    const OTHER_REGION_VA: u64 = vmm::USER_HEAP_END + 0x0010_0000;
+    assert!(
+        vmm::classify_user_region(OTHER_REGION_VA).is_none(),
+        "test VA must not fall inside any of the three known user regions"
+    );
+
+    let user_cr3 = vmm::clone_kernel_pml4_for_user();
+    let leaf = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("leaf frame allocation failed"));
+
+    let mapped_pfn = vmm::with_address_space(user_cr3, || {
+        vmm::try_map_virtual_to_physical(OTHER_REGION_VA, leaf.physical_address())
+            .expect("mapping an out-of-window VA should still succeed at the page-table level");
+        vmm::debug_mapped_pfn_for_va(OTHER_REGION_VA).expect("mapped leaf must resolve")
+    });
+    assert_eq!(
+        mapped_pfn, leaf.pfn,
+        "mapped leaf PFN must match the allocated frame"
+    );
+
+    vmm::destroy_user_address_space(user_cr3);
+
+    pmm::with_pmm(|mgr| {
+        assert!(
+            !mgr.release_pfn(leaf.pfn),
+            "teardown's catch-all pass must have already reclaimed the out-of-window mapping"
         );
     });
 }


### PR DESCRIPTION
## Summary

- Replaces the manual `release_user_code_pfns` boolean policy (used to avoid double-freeing user-code frames aliased over other mappings) with a per-frame refcount array in the PMM (`kernel/src/memory/pmm/types.rs`, `manager.rs`). `alloc_frame` initializes a fresh frame's count to 1; the new `inc_refcount(pfn)` bumps it when a frame gains an additional owner; `release_pfn` always decrements and only actually frees the frame (clears the bitmap bit) once the count reaches zero.
- All teardown call sites (`memory/vmm/mapping.rs`, `scheduler/roundrobin/*`, `process/loader.rs`) now call the refcounted `release_pfn` unconditionally instead of branching on a caller-supplied boolean. Removed the now-redundant `release_user_code_pfns` field from `TaskEntry`/`SpawnKind` and folded `destroy_user_address_space_with_options` into `destroy_user_address_space`/`_with_page_counts`.
- Extended `destroy_user_address_space_with_page_counts` with a generic catch-all pass (`reclaim_user_range`) that reclaims any present user mapping outside the fixed Code/Stack/Heap windows, bounded to the user PML4 slot range (`USER_ADDRESS_SPACE_SCAN_END`) so it can never touch the shared low-memory identity map or higher-half kernel slots. This means a future per-process region (e.g. `mmap` outside the heap window) can't be silently leaked at teardown.
- Updated the UEFI loader's PMM metadata reservation size calculation (`kaosldr_uefi/src/main.rs`) to also account for the new refcount array (it previously only sized for the bitmap), avoiding a potential real-hardware regression on large-RAM systems (see `docs/UEFI boot on real HW` history for why this class of bug matters).
- Updated `docs/pmm.md` to document the new `refcount_start`/`refcount_bytes` fields and the refcounting model.

## Tests

- `kernel/tests/pmm_test.rs`: added `test_pmm_single_owner_frame_freed_after_one_release`, `test_pmm_refcounted_frame_survives_until_last_release` (the core new behavior: a refcount-2 frame survives one `release_pfn` and is only freed by the second), and `test_pmm_inc_refcount_rejects_unallocated_or_out_of_range_pfn`.
- `kernel/tests/vmm_test.rs`: replaced the old boolean-policy tests with `test_destroy_user_address_space_releases_single_owner_code_leaf_frame`, `test_destroy_user_address_space_keeps_shared_code_leaf_frame_until_last_release` (mirrors the PMM-level shared-frame test at the VMM teardown layer), updated `test_destroy_user_address_space_with_page_counts_releases_mapped_code_and_stack_leaf_frames` for the new signature, and added `test_destroy_user_address_space_reclaims_mapping_outside_known_regions` to exercise the new catch-all reclaim pass.
- `kernel/tests/pmm_uefi_test.rs`: updated the synthetic metadata-size expectations (computed dynamically from the real struct sizes) to account for the new refcount array.
- Also fixed a handful of pre-existing clippy lint violations in unrelated test files (`serial_deadlock_test`, `time_test`, `console_flush_lock_test`, `syscall_dispatch_test`, `heap_test`) that were blocking a clean `cargo clippy --tests -- -D warnings` run.

## Verification

- `cargo test` (from `kernel/`): full suite passed — **350/350 test cases across 37 test files**.
- `cargo clippy -- -D warnings` and `cargo clippy --tests -- -D warnings` (from `kernel/`): clean.
- `cargo clippy -- -D warnings` (from `kaosldr_uefi/` and `kaosldr_64/`): clean.
- `cargo fmt --check` (workspace-wide, from `main64/`): clean.
- Note: `cargo clippy --workspace --all-targets` cannot run as a single invocation from `main64/` in this repo — each freestanding crate (`kernel`, `kaosldr_64`, `kaosldr_uefi`, `user_programs/*`) has its own `.cargo/config.toml`/target that only applies when the CWD is inside that crate's directory (confirmed this is pre-existing, unrelated to this change, by stashing and re-running against `origin/main`). Ran clippy per-crate instead, as shown above. `--all-targets` also can't build the kernel's implicit lib/bin unit-test harness on the `x86_64-unknown-none` target (`can't find crate for test`) — also pre-existing and unrelated; `--tests` is the correct target set for this `no_std` project's actual test suite per `docs/testing.md`.

Closes #15