### PR TITLE
C1: Gate panic framebuffer writer on FRAMEBUFFER_MAPPED to close early triple-fault

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -108,3 +108,6 @@ name = "fat32_concurrent_test"
 
 [[test]]
 name = "serial_deadlock_test"
+
+[[test]]
+name = "framebuffer_panic_gate_test"

--- a/main64/kernel/src/boot_info.rs
+++ b/main64/kernel/src/boot_info.rs
@@ -144,6 +144,26 @@ pub struct BootInfo {
 /// Memory Manager) read this pointer to access firmware tables.
 pub static BOOT_INFO_PTR: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
+/// Tracks whether the linear framebuffer reported in `BootInfo` has actually been
+/// mapped into the kernel address space yet.
+///
+/// `BOOT_INFO_PTR` is published (and `BootInfo.video_type` already reads
+/// `Framebuffer` on a BIOS+VBE boot) long before `map_framebuffer()` in `main.rs`
+/// runs — `gdt::init()`, `fpu::init()`, `pmm::init()`, `interrupts::init()`,
+/// `vmm::init()`, and `heap::init()` all execute in between. A panic during any of
+/// those early steps must NOT let the panic handler treat the framebuffer's base
+/// address as a valid, writable pointer: on BIOS+VBE that address lives outside the
+/// bootstrap loader's low identity map, and no page-fault handler is installed that
+/// early, so a write would triple-fault the CPU with zero diagnostic output.
+///
+/// Set to `true` (with `Release` ordering) only at the very end of `map_framebuffer()`,
+/// after every page of the framebuffer has been mapped. Readers (e.g. the panic
+/// handler) may use `Relaxed` loads: the flag itself is the synchronization point —
+/// it only ever transitions `false -> true`, and a stale `false` read merely causes
+/// the safe VGA-text fallback to be used instead of the framebuffer.
+pub static FRAMEBUFFER_MAPPED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
 impl BootInfo {
     /// Returns a static reference to the active `BootInfo` structure, if it has been validated and published.
     pub fn get() -> Option<&'static BootInfo> {
@@ -156,5 +176,40 @@ impl BootInfo {
             // - The boot loader guarantees the memory is valid and immutable for the kernel's lifetime.
             Some(unsafe { &*(ptr as *const BootInfo) })
         }
+    }
+}
+
+/// Decides whether it is currently safe to render panic diagnostics onto the linear
+/// framebuffer, as opposed to falling back to the legacy VGA text-mode writer.
+///
+/// This is the single seam shared by the panic path's writer-selection logic and this
+/// module's tests: it combines the two independent facts that must both hold before any
+/// code touches `fb_info.base_address` as a live pointer:
+/// 1. The active boot actually selected a linear framebuffer (`video_type ==
+///    Framebuffer` with a non-zero base address) rather than legacy VGA text mode.
+/// 2. `map_framebuffer()` has already run to completion and published
+///    [`FRAMEBUFFER_MAPPED`] — otherwise the address is a physical address that may sit
+///    outside the bootstrap loader's low identity map (BIOS+VBE case), with no
+///    page-fault handler installed early enough to survive a wild write.
+///
+/// Checking (2) first is deliberate: on a BIOS+VBE boot, `BootInfo.video_type` already
+/// reads `Framebuffer` the instant `BOOT_INFO_PTR` is published in `KernelMain` — long
+/// before `gdt::init()`, `pmm::init()`, `interrupts::init()`, `vmm::init()`, or
+/// `map_framebuffer()` run. A panic during any of those early steps must not be able to
+/// pick the framebuffer writer just because `video_type` looks right.
+pub fn framebuffer_panic_writer_available() -> bool {
+    // Step 1: gate on the mapping flag first. `Relaxed` is sufficient here: the flag
+    // only ever transitions `false -> true`, and the `Release` store in
+    // `map_framebuffer()` is the sole writer, so a stale `false` read merely defers
+    // to the always-safe VGA-text fallback rather than causing a hazard.
+    if !FRAMEBUFFER_MAPPED.load(core::sync::atomic::Ordering::Relaxed) {
+        return false;
+    }
+
+    // Step 2: only once mapping is confirmed, check whether the boot info actually
+    // describes a usable linear framebuffer.
+    match BootInfo::get() {
+        Some(bi) => bi.video_type == VideoModeType::Framebuffer && bi.fb_info.base_address != 0,
+        None => false,
     }
 }

--- a/main64/kernel/src/main.rs
+++ b/main64/kernel/src/main.rs
@@ -417,6 +417,14 @@ fn map_framebuffer(boot_info_raw: u64) {
         end,
         fb.size
     );
+
+    // Publish that the framebuffer is now safe to write to. The panic handler reads
+    // this flag before touching `fb.base_address`; setting it only here (after every
+    // page above has been mapped) is what prevents an early panic from triple-faulting
+    // by writing through a still-unmapped physical address. `Release` pairs with the
+    // `Relaxed` load in the panic path: the flag transitions only `false -> true`, so
+    // any observer either sees the fully-mapped framebuffer or safely falls back.
+    boot_info::FRAMEBUFFER_MAPPED.store(true, core::sync::atomic::Ordering::Release);
 }
 
 /// Converts higher-half kernel VA to physical address by removing base offset.

--- a/main64/kernel/src/panic.rs
+++ b/main64/kernel/src/panic.rs
@@ -2,7 +2,7 @@
 //!
 //! Required for `no_std` environments.
 
-use crate::boot_info::{BootInfo, PixelFormat, VideoModeType, BOOT_INFO_PTR};
+use crate::boot_info::{framebuffer_panic_writer_available, BootInfo, PixelFormat, BOOT_INFO_PTR};
 use crate::console::FramebufferConsole;
 use crate::drivers::screen::Color;
 use core::fmt::Write;
@@ -44,8 +44,25 @@ struct PanicFramebufferWriter {
 
 impl PanicFramebufferWriter {
     /// Builds a writer from the published boot info, or `None` when the active
-    /// boot is not a usable linear framebuffer (e.g. legacy VGA text mode).
+    /// boot is not a usable linear framebuffer (e.g. legacy VGA text mode) or the
+    /// framebuffer has not been mapped into the address space yet.
     fn from_boot_info() -> Option<Self> {
+        // Gate on the shared predicate before treating `fb_info.base_address` as a
+        // live pointer. `BOOT_INFO_PTR` is published (and `video_type` may already
+        // read `Framebuffer` on a BIOS+VBE boot) well before `map_framebuffer()` runs
+        // in `KernelMain` — `gdt::init()`, `fpu::init()`, `pmm::init()`,
+        // `interrupts::init()`, `vmm::init()`, and `heap::init()` all execute first.
+        // A panic during any of those steps must not treat the framebuffer address as
+        // valid and writable: on BIOS+VBE it lives outside the bootstrap loader's low
+        // identity map, and no fault handler exists that early, so the write would
+        // triple-fault the CPU with zero diagnostic output. Bail out to the VGA-text
+        // fallback (always safe, within the low identity map) until
+        // `framebuffer_panic_writer_available()` confirms both that a framebuffer
+        // boot was selected AND that it has actually been mapped.
+        if !framebuffer_panic_writer_available() {
+            return None;
+        }
+
         let raw = BOOT_INFO_PTR.load(Ordering::Relaxed);
         if raw == 0 {
             return None;
@@ -53,9 +70,6 @@ impl PanicFramebufferWriter {
         // SAFETY: `raw` is the boot-info pointer published in `KernelMain` after a
         // magic check; the structure lives in identity-mapped low memory.
         let bi = unsafe { &*(raw as *const BootInfo) };
-        if bi.video_type != VideoModeType::Framebuffer || bi.fb_info.base_address == 0 {
-            return None;
-        }
         let fb = bi.fb_info;
         Some(Self {
             base: fb.base_address as *mut u32,

--- a/main64/kernel/tests/framebuffer_panic_gate_test.rs
+++ b/main64/kernel/tests/framebuffer_panic_gate_test.rs
@@ -1,0 +1,184 @@
+//! Contract test for the C1 fix: the panic path must never treat the linear
+//! framebuffer as a live, writable pointer before it has actually been mapped.
+//!
+//! # Background
+//!
+//! `BOOT_INFO_PTR` is published in `KernelMain` right after the boot-info magic
+//! check succeeds — before `gdt::init()`, `fpu::init()`, `pmm::init()`,
+//! `interrupts::init()`, `vmm::init()`, `heap::init()`, or `map_framebuffer()` run.
+//! `BootInfo.video_type` is set by the bootloader, not the kernel, so on a BIOS+VBE
+//! boot it already reads `Framebuffer` at the moment `BOOT_INFO_PTR` is published.
+//!
+//! A panic between that publish and `map_framebuffer()` running (e.g. from
+//! `pmm::init()` hitting a malformed memory map) must not pick the framebuffer
+//! writer: on BIOS+VBE the reported base address lives outside the bootstrap
+//! loader's low identity map, and no page-fault/IDT handler exists yet, so writing
+//! through it would triple-fault the CPU with zero diagnostic output.
+//!
+//! # Test seam
+//!
+//! `panic.rs` (and its `PanicFramebufferWriter`) is intentionally excluded from the
+//! `kaos_kernel` library target (see `kernel/src/lib.rs`): it defines the crate's
+//! `#[panic_handler]`, and every integration test binary supplies its own — pulling
+//! `panic.rs` into the library would collide with that. So this test exercises the
+//! shared predicate the panic path is built on,
+//! `kaos_kernel::boot_info::framebuffer_panic_writer_available()`, which is the exact
+//! gate `PanicFramebufferWriter::from_boot_info()` checks first. That function is a
+//! pure combination of `FRAMEBUFFER_MAPPED` and the published `BootInfo`, with no
+//! hardware/heap dependency, making it the most direct testable seam for this fix.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+use core::sync::atomic::Ordering;
+
+use kaos_kernel::boot_info::{
+    framebuffer_panic_writer_available, BootInfo, FramebufferInfo, PixelFormat, VideoModeType,
+    BOOT_INFO_PTR, FRAMEBUFFER_MAPPED,
+};
+
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+    test_main();
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    kaos_kernel::testing::test_panic_handler(info)
+}
+
+/// Builds a `BootInfo` describing a BIOS+VBE-style framebuffer boot: a valid magic,
+/// `video_type == Framebuffer`, and a non-zero `fb_info.base_address`. This mirrors
+/// what the bootloader publishes *before* the kernel has mapped anything.
+fn framebuffer_boot_info() -> BootInfo {
+    BootInfo {
+        magic: 0x4B41_4F53_5F42_4F4F,
+        video_type: VideoModeType::Framebuffer,
+        fb_info: FramebufferInfo {
+            base_address: 0xE000_0000,
+            size: 0x40_0000,
+            width: 1024,
+            height: 768,
+            pixels_per_scanline: 1024,
+            pixel_format: PixelFormat::Bgr,
+        },
+        memory_map_addr: 0,
+        memory_map_len: 0,
+        kernel_size: 0,
+        pmm_metadata_base: 0,
+        pmm_metadata_size: 0,
+        boot_year: 0,
+        boot_month: 0,
+        boot_day: 0,
+        boot_hour: 0,
+        boot_minute: 0,
+        boot_second: 0,
+        boot_timezone: 0,
+    }
+}
+
+/// Restores the two globals under test to their pre-test state so this test does not
+/// leak state into any test that runs after it in the same binary.
+fn reset_globals(saved_ptr: u64, saved_mapped: bool) {
+    BOOT_INFO_PTR.store(saved_ptr, Ordering::Release);
+    FRAMEBUFFER_MAPPED.store(saved_mapped, Ordering::Relaxed);
+}
+
+/// Contract: even when `BootInfo.video_type == Framebuffer` (as it already is on a
+/// BIOS+VBE boot the instant `BOOT_INFO_PTR` is published), the gate must return
+/// `false` while `FRAMEBUFFER_MAPPED` is still `false` — i.e. before `map_framebuffer()`
+/// has run. This is exactly the window in which `pmm::init()`, `vmm::init()`, etc. can
+/// panic.
+/// Failure Impact: the panic handler would pick the framebuffer writer before the
+/// framebuffer is mapped, writing through an unmapped physical address and
+/// triple-faulting the CPU with zero diagnostic output (C1 / #41). Release-blocking.
+#[test_case]
+fn test_gate_false_when_video_type_framebuffer_but_not_mapped() {
+    let saved_ptr = BOOT_INFO_PTR.load(Ordering::Acquire);
+    let saved_mapped = FRAMEBUFFER_MAPPED.load(Ordering::Relaxed);
+
+    let boot_info = framebuffer_boot_info();
+    let ptr = &boot_info as *const BootInfo as u64;
+
+    // SAFETY: `boot_info` is a live local on this function's stack; this mirrors
+    // `KernelMain` publishing `BOOT_INFO_PTR` right after the magic check, before
+    // `map_framebuffer()` has ever run. The pointer is restored below before this
+    // stack frame returns.
+    BOOT_INFO_PTR.store(ptr, Ordering::Release);
+    FRAMEBUFFER_MAPPED.store(false, Ordering::Relaxed);
+
+    let available = framebuffer_panic_writer_available();
+
+    reset_globals(saved_ptr, saved_mapped);
+
+    kaos_kernel::test_assert!(
+        !available,
+        "framebuffer_panic_writer_available() must be false before map_framebuffer() runs, \
+         even though video_type already reads Framebuffer"
+    );
+}
+
+/// Contract: once `FRAMEBUFFER_MAPPED` is `true` (i.e. `map_framebuffer()` has run to
+/// completion) and `BootInfo` describes a valid framebuffer, the gate must return
+/// `true` so the panic path can render diagnostics to VRAM instead of falling back
+/// to VGA text mode.
+/// Failure Impact: a regression here would either re-introduce the triple-fault (if
+/// the gate stayed stuck at `false`) or mask that the fallback path is the only one
+/// ever exercised. Release-blocking.
+#[test_case]
+fn test_gate_true_once_mapped() {
+    let saved_ptr = BOOT_INFO_PTR.load(Ordering::Acquire);
+    let saved_mapped = FRAMEBUFFER_MAPPED.load(Ordering::Relaxed);
+
+    let boot_info = framebuffer_boot_info();
+    let ptr = &boot_info as *const BootInfo as u64;
+
+    // SAFETY: see `test_gate_false_when_video_type_framebuffer_but_not_mapped`; same
+    // stack-local publish/restore discipline.
+    BOOT_INFO_PTR.store(ptr, Ordering::Release);
+    FRAMEBUFFER_MAPPED.store(true, Ordering::Release);
+
+    let available = framebuffer_panic_writer_available();
+
+    reset_globals(saved_ptr, saved_mapped);
+
+    kaos_kernel::test_assert!(
+        available,
+        "framebuffer_panic_writer_available() must be true once map_framebuffer() has \
+         published FRAMEBUFFER_MAPPED and BootInfo describes a valid framebuffer"
+    );
+}
+
+/// Contract: when no `BootInfo` has been published at all (`BOOT_INFO_PTR == 0`), the
+/// gate must be `false` regardless of `FRAMEBUFFER_MAPPED` — there is nothing to read
+/// `fb_info` from.
+/// Failure Impact: a null/garbage read of `BootInfo` on a boot path without a unified
+/// boot-info block (e.g. the legacy `KernelMain(kernel_size)` compatibility path).
+/// Release-blocking.
+#[test_case]
+fn test_gate_false_when_no_boot_info_published() {
+    let saved_ptr = BOOT_INFO_PTR.load(Ordering::Acquire);
+    let saved_mapped = FRAMEBUFFER_MAPPED.load(Ordering::Relaxed);
+
+    BOOT_INFO_PTR.store(0, Ordering::Release);
+    FRAMEBUFFER_MAPPED.store(true, Ordering::Relaxed);
+
+    let available = framebuffer_panic_writer_available();
+
+    reset_globals(saved_ptr, saved_mapped);
+
+    kaos_kernel::test_assert!(
+        !available,
+        "framebuffer_panic_writer_available() must be false when no BootInfo has been \
+         published, even if FRAMEBUFFER_MAPPED is stale-true"
+    );
+}


### PR DESCRIPTION
## Summary

- `BOOT_INFO_PTR` is published in `KernelMain` right after the boot-info magic check succeeds — before `gdt::init()`, `fpu::init()`, `pmm::init()`, `interrupts::init()`, `vmm::init()`, `heap::init()`, or `map_framebuffer()` run. On a BIOS+VBE boot, `BootInfo.video_type` already reads `Framebuffer` at that moment (it's set by the bootloader, not the kernel), so `PanicFramebufferWriter::from_boot_info()` in `kernel/src/panic.rs` would treat `fb_info.base_address` as an already-mapped, writable pointer as soon as `video_type == Framebuffer`, with no check for whether the framebuffer had actually been mapped yet.
- Adds `boot_info::FRAMEBUFFER_MAPPED` (`AtomicBool`), set with `Release` ordering only at the very end of `map_framebuffer()` in `kernel/src/main.rs`, after every page of the framebuffer has actually been mapped.
- Adds `boot_info::framebuffer_panic_writer_available()`, a shared predicate that checks `FRAMEBUFFER_MAPPED` (Relaxed) first, then whether `BootInfo` describes a usable framebuffer. `PanicFramebufferWriter::from_boot_info()` now calls this predicate before touching `fb_info` at all, returning `None` (falling back to the VGA-text `PanicScreenWriter` at `0xB8000`, always safe within the low identity map) until the framebuffer is confirmed mapped.

## Failure scenario this closes

Any panic between the `BOOT_INFO_PTR` publish and `map_framebuffer()` running (e.g. `pmm::init()` hitting a malformed memory map) used to enter the panic handler, which picked the framebuffer branch and wrote through the unmapped physical address — triple-faulting the CPU with zero diagnostic output, defeating the entire purpose of the panic handler. The panic handler now correctly falls back to the VGA-text writer in that window instead.

## Testing

- `panic.rs` is intentionally excluded from the `kaos_kernel` lib target (it owns the crate's `#[panic_handler]`, which would collide with every test binary's own handler), so the new predicate lives in `boot_info.rs` (already part of the lib) as the most direct testable seam.
- Added `kernel/tests/framebuffer_panic_gate_test.rs` with 3 cases:
  - gate is `false` when `video_type == Framebuffer` but `FRAMEBUFFER_MAPPED` is still `false`
  - gate is `true` once `FRAMEBUFFER_MAPPED` is set and `BootInfo` describes a valid framebuffer
  - gate is `false` when no `BootInfo` has been published at all

`cargo test`, `cargo clippy`, and `cargo fmt --check` all pass cleanly (362/362 test cases across 33 test files, zero clippy warnings introduced, zero fmt diffs).

Closes #41