### PR TITLE
H2: Fix test-framework panic handler dropping formatted assertion messages

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -108,3 +108,6 @@ name = "fat32_concurrent_test"
 
 [[test]]
 name = "serial_deadlock_test"
+
+[[test]]
+name = "test_framework_panic_message_test"

--- a/main64/kernel/src/testing.rs
+++ b/main64/kernel/src/testing.rs
@@ -97,9 +97,14 @@ pub fn test_panic_handler(info: &core::panic::PanicInfo) -> ! {
         debugln!("  Location: {}:{}", location.file(), location.line());
     }
 
-    if let Some(message) = info.message().as_str() {
-        debugln!("  Message: {}", message);
-    }
+    // `PanicMessage::as_str()` only returns `Some` for a panic built from a
+    // bare string literal with no format arguments. `test_assert_eq!` and
+    // `test_assert!` always panic with interpolated arguments (see below), so
+    // an `as_str()`-based check silently drops the message for essentially
+    // every real assertion failure. `PanicMessage` always implements
+    // `Display`, so format it directly instead - this mirrors the panic
+    // path in `panic.rs`, which never had this bug.
+    debugln!("  Message: {}", info.message());
 
     debugln!();
     print_summary();

--- a/main64/kernel/tests/test_framework_panic_message_test.rs
+++ b/main64/kernel/tests/test_framework_panic_message_test.rs
@@ -1,0 +1,80 @@
+//! Regression test for H2 (issue #43): the test-framework panic handler must
+//! not drop interpolated panic messages.
+//!
+//! `test_panic_handler` in `kernel/src/testing.rs` used to print the panic
+//! message only via `PanicMessage::as_str()`, which returns `Some` only for a
+//! bare string-literal panic with no format arguments. Every real assertion
+//! failure produced by `test_assert_eq!`/`test_assert!` panics with
+//! interpolated arguments (e.g. `panic!("... {:?} ...", left, right)`), so the
+//! diagnostic message was silently skipped for essentially every real test
+//! failure - defeating the purpose of the assertion macros.
+//!
+//! This binary cannot invoke `test_panic_handler` itself and then inspect its
+//! `debugln!` output from `cargo test`: the harness only observes the QEMU
+//! exit code produced by `tests/test_runner.sh`, not serial content. Instead
+//! this test exercises the exact seam the fix relies on: formatting
+//! `PanicInfo::message()` via `Display` (as `test_panic_handler` now does)
+//! rather than via `Option::as_str()` (the old, buggy behavior). We
+//! deliberately trigger a panic the same way `test_assert_eq!` does - with
+//! interpolated arguments - and use `panic_message_contains` (which already
+//! formats via `Display`) to confirm the interpolated values survive.
+//! Under the pre-fix logic, an `as_str()`-based check on this same panic
+//! would have observed `None` and dropped the message entirely.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+use kaos_kernel::arch::qemu::{exit_qemu, QemuExitCode};
+
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+    test_main();
+
+    // If this is reached, the expected panic did not happen.
+    exit_qemu(QemuExitCode::Failed);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    // Both interpolated values must be present in the `Display`-formatted
+    // message. A `.as_str()`-based check (the pre-fix behavior of
+    // `test_panic_handler`) would see `None` for this panic, since it was
+    // built with format arguments - making this contract unverifiable and
+    // silently dropping the diagnostic in the real failure path.
+    //
+    // `panic_message_contains` scans one formatter `write_str` chunk at a
+    // time (see its doc comment in `testing.rs`) and does not stitch
+    // adjacent chunks together, so a search string that straddles a chunk
+    // boundary - e.g. static text immediately followed by a `{:?}`-formatted
+    // argument - can miss even though the full message contains it. To keep
+    // this test independent of that separately-tracked limitation, we search
+    // only for each interpolated numeric literal on its own, which is
+    // rendered as a single `write_str` chunk by the integer `Debug` impl.
+    let has_left = kaos_kernel::testing::panic_message_contains(info, "246813579");
+    let has_right = kaos_kernel::testing::panic_message_contains(info, "987654321");
+
+    if has_left && has_right {
+        exit_qemu(QemuExitCode::Success);
+    } else {
+        exit_qemu(QemuExitCode::Failed);
+    }
+}
+
+/// Contract: a panic constructed with format arguments - exactly how
+/// `test_assert_eq!` builds its panic on failure - retains the interpolated
+/// values when the message is rendered via `Display`.
+/// Given: `test_assert_eq!` is invoked with two unequal, distinctive values.
+/// When: the assertion fails and panics with an interpolated message.
+/// Then: the panic message, read via `Display` (as `test_panic_handler` now
+/// does), contains both interpolated values instead of being dropped, as it
+/// would be with the pre-fix `as_str()`-based check.
+#[test_case]
+fn test_formatted_assertion_panic_retains_interpolated_values() {
+    kaos_kernel::test_assert_eq!(246813579, 987654321);
+}


### PR DESCRIPTION
## Summary

- `test_panic_handler()` in `kernel/src/testing.rs` printed the panic message only when `PanicMessage::as_str()` returned `Some`, which happens only for a bare string-literal panic with no format arguments.
- `test_assert_eq!`/`test_assert!` always panic with interpolated arguments (e.g. `panic!("... {:?} ...", left, right)`), so the `Message:` line was silently skipped for essentially every real test failure - defeating the diagnostic purpose of the entire assertion framework. Anyone debugging a CI failure from the serial log alone had to re-run locally or read the source to guess what failed.
- Fix mirrors the already-correct production panic path in `kernel/src/panic.rs`, which formats `info.message()` unconditionally via `Display` instead of gating on `as_str()`.

## Failure scenario closed

Before: `test_assert_eq!(result, 42)` failing with `result == 7` produced `[FAILED]`, file:line, and summary counts, but never the actual `left`/`right` values.

After: the interpolated values are always printed via `Display`, regardless of whether the panic message was a bare literal or built with format arguments.

## Changes

- `kernel/src/testing.rs`: replace the `Option`-based `as_str()` check with a direct `Display`-based print (`debugln!("  Message: {}", info.message());`).
- `kernel/tests/test_framework_panic_message_test.rs` (new): integration test that triggers a `test_assert_eq!` failure with interpolated, distinctive numeric values and verifies via `panic_message_contains` (which formats via `Display`) that the interpolated values survive - exercising the exact defect class described in the bug report. A comment documents why the search terms are chosen to avoid the separately-tracked chunk-boundary limitation of `panic_message_contains`.
- `kernel/Cargo.toml`: register the new integration test target, consistent with the other explicitly listed panic-contract tests.

## Test plan

All three required checks pass cleanly from `main64/`:
- [x] `cargo test` (from `main64/kernel`) - all 33 test binaries / 360 test cases pass, including the new regression test
- [x] `cargo clippy --tests` (from `main64/kernel`) - zero new warnings (one pre-existing, unrelated warning in `vmm_test.rs` untouched by this change)
- [x] `cargo fmt --check` (from `main64/`) - zero diffs

Closes #43