### PR TITLE
Driver layer robustness & documentation (AHCI, framebuffer, keyboard) - #61

### DIFF
--- a/main64/kernel/src/console/framebuffer.rs
+++ b/main64/kernel/src/console/framebuffer.rs
@@ -643,11 +643,14 @@ impl KernelConsole for FramebufferConsole {
     }
 
     fn disable_blink_mode(&mut self) {
-        // No-op for framebuffer.
+        // No-op: blink mode is a VGA text-mode attribute-controller concept
+        // that has no equivalent on a pixel framebuffer. See the trait-level
+        // contract on `KernelConsole::disable_blink_mode`.
     }
 
     fn enable_blink_mode(&mut self) {
-        // No-op for framebuffer.
+        // No-op: see `disable_blink_mode` above and the trait-level contract
+        // on `KernelConsole::enable_blink_mode`.
     }
 
     fn take_pending_flush(&mut self) -> Option<PendingFlush> {

--- a/main64/kernel/src/console/interface.rs
+++ b/main64/kernel/src/console/interface.rs
@@ -85,9 +85,20 @@ pub trait KernelConsole: core::fmt::Write + Send {
     fn enable_hw_cursor(&mut self);
 
     /// Disables VGA blinking mode, enabling all 16 colors to be used as backgrounds.
+    ///
+    /// This toggles a VGA-attribute-controller-specific bit (the "blink vs.
+    /// intense background" selector) and has no equivalent concept on
+    /// non-VGA backends. Implementors that do not render through the VGA
+    /// text-mode attribute controller (e.g. `FramebufferConsole`) MUST treat
+    /// this as a silent no-op rather than erroring, since callers are not
+    /// expected to branch on the active backend before calling it.
     fn disable_blink_mode(&mut self);
 
     /// Restores default VGA text mode blinking behavior.
+    ///
+    /// VGA-specific, like [`KernelConsole::disable_blink_mode`]; a no-op on
+    /// backends that do not implement VGA-style attribute-controller
+    /// blinking (e.g. `FramebufferConsole`).
     fn enable_blink_mode(&mut self);
 
     /// Extracts any VRAM upload queued by preceding drawing operations on this

--- a/main64/kernel/src/drivers/ahci.rs
+++ b/main64/kernel/src/drivers/ahci.rs
@@ -571,6 +571,54 @@ pub enum AhciError {
     NotInitialized,
     PortError,
     Timeout,
+
+    /// `sector_count == 0` was requested.
+    ///
+    /// Unlike a normal "nothing to do" case, this is rejected rather than
+    /// treated as a silent no-op: AHCI task files interpret a zero sector
+    /// count as a request for the maximum transfer size for the active
+    /// command (e.g. 65536 sectors for 48-bit LBA reads/writes), so silently
+    /// continuing would mis-program the device instead of doing nothing.
+    InvalidSectorCount,
+
+    /// The transfer does not fit in the fixed-size PRDT (see
+    /// [`HbaCmdTbl::prdt_entry`]) even in the worst case of maximal
+    /// physical-page fragmentation.
+    PrdtOverflow,
+}
+
+/// Maximum number of Physical Region Descriptor Table entries available in
+/// one command table (see [`HbaCmdTbl::prdt_entry`]).
+pub const MAX_PRDT_ENTRIES: usize = 44;
+
+/// Computes the worst-case number of PRDT entries needed to describe a
+/// transfer of `total_bytes`, assuming the least favorable starting
+/// physical-page alignment.
+///
+/// The real fragmentation loop in [`do_transfer`] emits one PRDT entry per
+/// contiguous physical-page run, so a buffer that starts one byte before a
+/// page boundary produces the most entries: a 1-byte first chunk, then one
+/// entry per subsequent full 4 KiB page. This helper is pure and
+/// hardware-independent (no port I/O, no page-table walk) so callers can use
+/// it to reject an oversized request up front.
+///
+/// Exposed (not just `pub(crate)`) so integration tests can exercise the
+/// validation logic directly: `do_transfer`'s hardware path cannot be driven
+/// end-to-end without a mapped AHCI port, which is not present in every test
+/// environment (e.g. default QEMU without `-device ahci`).
+pub const fn max_prdt_entries_for(total_bytes: usize) -> usize {
+    if total_bytes == 0 {
+        return 0;
+    }
+
+    // Worst case: 1 byte in the first (unaligned) page, then a full page
+    // per remaining entry.
+    const FIRST_CHUNK: usize = 1;
+    if total_bytes <= FIRST_CHUNK {
+        return 1;
+    }
+
+    1 + (total_bytes - FIRST_CHUNK).div_ceil(4096)
 }
 
 fn virt_to_phys(va: u64) -> Option<u64> {
@@ -613,10 +661,23 @@ fn virt_to_phys(va: u64) -> Option<u64> {
 }
 
 pub fn read_sectors(buffer: &mut [u8], lba: u64, sector_count: u32) -> Result<(), AhciError> {
+    // Self-contained guard: reject an ambiguous zero-sector request before
+    // touching any hardware state (see `AhciError::InvalidSectorCount`).
+    // `block.rs` already guards this for its current callers, but this
+    // function must not rely on caller discipline for a future caller.
+    if sector_count == 0 {
+        return Err(AhciError::InvalidSectorCount);
+    }
+
     do_transfer(buffer.as_mut_ptr(), buffer.len(), lba, sector_count, false)
 }
 
 pub fn write_sectors(buffer: &[u8], lba: u64, sector_count: u32) -> Result<(), AhciError> {
+    // Self-contained guard: same rationale as `read_sectors` above.
+    if sector_count == 0 {
+        return Err(AhciError::InvalidSectorCount);
+    }
+
     do_transfer(
         buffer.as_ptr() as *mut u8,
         buffer.len(),
@@ -641,6 +702,15 @@ fn do_transfer(
         buffer_len >= total_bytes,
         "Buffer too small for AHCI transfer"
     );
+
+    // Reject transfers that cannot possibly fit in the fixed-size PRDT even
+    // in the worst-case fragmentation scenario, before any port I/O is
+    // issued. This turns what used to be a mid-transfer panic (see the PRDT
+    // fragmentation loop below) into a recoverable error returned to the
+    // caller.
+    if max_prdt_entries_for(total_bytes) > MAX_PRDT_ENTRIES {
+        return Err(AhciError::PrdtOverflow);
+    }
 
     unsafe {
         let p = &mut *port;
@@ -689,10 +759,14 @@ fn do_transfer(
         let mut current_va = buffer_ptr as u64;
 
         while remaining_bytes > 0 {
-            assert!(
-                prdtl < 44,
-                "AHCI transfer fragmented into too many PRDT entries"
-            );
+            // Defense-in-depth: the upfront `max_prdt_entries_for` check above
+            // should already guarantee this never trips, but actual physical
+            // fragmentation is only known here (it depends on the live page
+            // table), so this remains a returned error rather than a panic
+            // in case that estimate is ever wrong.
+            if prdtl >= MAX_PRDT_ENTRIES {
+                return Err(AhciError::PrdtOverflow);
+            }
             let phys_addr = virt_to_phys(current_va).expect("AHCI: Unmapped buffer VA");
             let bytes_in_page = 4096 - (phys_addr & 0xFFF);
             let chunk_size = remaining_bytes.min(bytes_in_page as usize);

--- a/main64/kernel/src/drivers/keyboard.rs
+++ b/main64/kernel/src/drivers/keyboard.rs
@@ -96,6 +96,18 @@ struct KeyboardState {
     left_ctrl: bool,
     /// Set when the previous scancode was the 0xE0 extended-key prefix.
     extended: bool,
+    /// Number of remaining bytes still expected as part of an in-progress
+    /// Pause/Break (0xE1-prefixed) scancode sequence.
+    ///
+    /// The Pause key has no distinct break code: pressing it sends the fixed
+    /// 6-byte make sequence `E1 1D 45 E1 9D C5` and nothing on release. When
+    /// the leading `0xE1` is seen this is set to the count of remaining
+    /// bytes in that sequence (5); each subsequent scancode decrements it
+    /// and is consumed as a no-op instead of falling through to the
+    /// modifier/ASCII decode path, where the trailing bytes (which alias
+    /// LCtrl make/break and NumLock-adjacent codes) would otherwise be
+    /// misinterpreted as unrelated key events.
+    pause_remaining: u8,
 }
 
 impl KeyboardState {
@@ -105,6 +117,7 @@ impl KeyboardState {
             caps_lock: false,
             left_ctrl: false,
             extended: false,
+            pause_remaining: 0,
         }
     }
 }
@@ -418,6 +431,24 @@ pub fn process_pending_scancodes() -> bool {
 }
 
 fn handle_scancode(state: &mut KeyboardState, code: u8) {
+    // Consume any byte still owed to an in-progress Pause/Break (0xE1)
+    // sequence before interpreting it as anything else — the sequence's
+    // interior bytes alias other keys' make/break codes and must not be
+    // decoded on their own.
+    if state.pause_remaining > 0 {
+        state.pause_remaining -= 1;
+        return;
+    }
+
+    // 0xE1 marks the start of the Pause/Break key's fixed 6-byte make
+    // sequence (`E1 1D 45 E1 9D C5`), which has no distinct break code.
+    // Record how many further bytes belong to it and consume this prefix
+    // byte without producing any key event.
+    if code == 0xE1 {
+        state.pause_remaining = 5;
+        return;
+    }
+
     // 0xE0 marks the start of a two-byte extended scancode sequence.
     // Record the flag and consume the prefix without producing any key event.
     if code == 0xE0 {

--- a/main64/kernel/tests/block_test.rs
+++ b/main64/kernel/tests/block_test.rs
@@ -158,3 +158,95 @@ fn test_ahci_concurrent_readers_and_multi_sector() {
         );
     }
 }
+
+/// Contract: AHCI read_sectors rejects sector_count == 0 without touching hardware.
+/// Given: No AHCI port needs to be initialized, since the zero-count guard in
+///   `read_sectors` must run before any hardware is touched (issue #61, L8).
+/// When: `read_sectors` is called with `sector_count == 0`.
+/// Then: The call returns `AhciError::InvalidSectorCount`, not `NotInitialized`
+///   or a panic — proving the guard is self-contained and runs first.
+/// Failure Impact: A future caller that does not pre-validate sector_count (unlike
+///   `block.rs`'s current chunking helper) could mis-program the controller, since
+///   AHCI interprets a zero sector count as a request for the maximum transfer size.
+#[test_case]
+fn test_ahci_read_sectors_rejects_zero_sector_count() {
+    let mut buf = [0u8; 512];
+    let result = ahci::read_sectors(&mut buf, 0, 0);
+
+    assert!(
+        matches!(result, Err(ahci::AhciError::InvalidSectorCount)),
+        "read_sectors must reject sector_count == 0 with InvalidSectorCount"
+    );
+}
+
+/// Contract: AHCI write_sectors rejects sector_count == 0 without touching hardware.
+/// Given/When/Then: mirrors `test_ahci_read_sectors_rejects_zero_sector_count` for
+///   the write path.
+#[test_case]
+fn test_ahci_write_sectors_rejects_zero_sector_count() {
+    let buf = [0xA5u8; 512];
+    let result = ahci::write_sectors(&buf, 0, 0);
+
+    assert!(
+        matches!(result, Err(ahci::AhciError::InvalidSectorCount)),
+        "write_sectors must reject sector_count == 0 with InvalidSectorCount"
+    );
+}
+
+/// Contract: `max_prdt_entries_for` matches the fixed PRDT capacity boundary.
+/// Given: The command table's PRDT holds `AhciError`-adjacent constant
+///   `ahci::MAX_PRDT_ENTRIES` (44) entries.
+/// When: Computing the worst-case entry count for transfer sizes at, just
+///   below, and just above the largest transfer that still fits.
+/// Then: The helper's result crosses the `MAX_PRDT_ENTRIES` boundary exactly
+///   where a real transfer of that size would overflow the PRDT — this is the
+///   pure, hardware-independent seam that stands in for `do_transfer`'s
+///   PRDT-overflow check, which cannot be driven end-to-end without a mapped
+///   AHCI port (not present in every test environment).
+/// Failure Impact: An off-by-one here would either reject legitimate transfers
+///   or let an oversized transfer reach the formerly-panicking assert path.
+#[test_case]
+fn test_ahci_max_prdt_entries_for_boundary() {
+    assert_eq!(
+        ahci::max_prdt_entries_for(0),
+        0,
+        "an empty transfer needs no PRDT entries"
+    );
+
+    // Largest transfer that still fits in MAX_PRDT_ENTRIES worst-case entries:
+    // 1 byte in the first (unaligned) page, then (MAX_PRDT_ENTRIES - 1) full
+    // 4 KiB pages.
+    let max_fitting_bytes = 1 + (ahci::MAX_PRDT_ENTRIES - 1) * 4096;
+    assert_eq!(
+        ahci::max_prdt_entries_for(max_fitting_bytes),
+        ahci::MAX_PRDT_ENTRIES,
+        "largest fitting transfer must need exactly MAX_PRDT_ENTRIES entries"
+    );
+
+    // One byte more must require one additional PRDT entry, overflowing the
+    // fixed-size table.
+    assert_eq!(
+        ahci::max_prdt_entries_for(max_fitting_bytes + 1),
+        ahci::MAX_PRDT_ENTRIES + 1,
+        "a transfer one byte larger must overflow MAX_PRDT_ENTRIES"
+    );
+}
+
+/// Contract: a transfer whose worst-case PRDT need exceeds capacity is rejected
+/// with `AhciError::PrdtOverflow` rather than being sent to `do_transfer`'s
+/// panicking assert path.
+/// Given: `MAX_PRDT_ENTRIES` is the fixed PRDT capacity and
+///   `max_prdt_entries_for` computes the worst-case entries needed.
+/// When: A byte count that needs `MAX_PRDT_ENTRIES + 1` entries is evaluated
+///   against the capacity, mirroring the guard added to `do_transfer`.
+/// Then: The guard condition used in `do_transfer` (`max_prdt_entries_for(n) >
+///   MAX_PRDT_ENTRIES`) evaluates to `true`, i.e. the request would be rejected.
+#[test_case]
+fn test_ahci_prdt_overflow_guard_condition_trips_for_oversized_transfer() {
+    let oversized_bytes = 1 + ahci::MAX_PRDT_ENTRIES * 4096;
+
+    assert!(
+        ahci::max_prdt_entries_for(oversized_bytes) > ahci::MAX_PRDT_ENTRIES,
+        "guard condition must trip for a transfer that cannot fit in the PRDT"
+    );
+}

--- a/main64/kernel/tests/keyboard_e2e_test.rs
+++ b/main64/kernel/tests/keyboard_e2e_test.rs
@@ -425,3 +425,52 @@ fn test_keyboard_clear_buffers_drains_all_inputs() {
         "key buffer must be empty after clear_buffers"
     );
 }
+
+/// Contract: the Pause/Break key's 0xE1-prefixed 6-byte make sequence is
+/// consumed as a recognized no-op and does not leak a bogus key event.
+/// Given: The keyboard driver is initialized (issue #61, L18).
+/// When: The full Pause make sequence `E1 1D 45 E1 9D C5` is enqueued and
+///   processed. The Pause key has no distinct break code, so this is the
+///   entire event for a single Pause key press.
+/// Then: No character and no `Key` event are produced by the sequence, and
+///   the state machine returns to a clean state so a subsequent, unrelated
+///   scancode still decodes correctly (proving the sequence's interior bytes
+///   — which alias LCtrl make/break and other codes — were not
+///   misinterpreted as separate key events).
+/// Failure Impact: Before this fix, the sequence's interior bytes fell
+///   through to the normal make/break decode path, which could spuriously
+///   toggle modifier state (e.g. LCtrl) or emit garbage key events.
+#[test_case]
+fn test_pause_key_scancode_sequence_is_consumed_as_no_op() {
+    keyboard::init();
+
+    // Full Pause/Break make sequence: E1 1D 45 E1 9D C5 (no break code exists).
+    for code in [0xE1u8, 0x1D, 0x45, 0xE1, 0x9D, 0xC5] {
+        keyboard::enqueue_raw_scancode(code);
+    }
+    assert!(
+        keyboard::process_pending_scancodes(),
+        "worker iteration must process the queued Pause sequence bytes"
+    );
+
+    assert!(
+        keyboard::read_char().is_none(),
+        "Pause sequence must not produce a decoded ASCII character"
+    );
+    assert!(
+        keyboard::read_key().is_none(),
+        "Pause sequence must not produce a decoded Key event"
+    );
+
+    // Follow-up scancode must decode normally, proving the sequence left no
+    // stuck state (e.g. a still-pending byte count or stuck LCtrl modifier).
+    keyboard::enqueue_raw_scancode(0x1e);
+    assert!(
+        keyboard::process_pending_scancodes(),
+        "worker iteration should process the post-Pause scancode"
+    );
+    assert!(
+        keyboard::read_char() == Some(b'a'),
+        "scancode after a Pause sequence must decode normally"
+    );
+}


### PR DESCRIPTION
## Summary

Three LOW-severity driver-layer findings from the review (issue #61): missing defense-in-depth input validation and missing/incomplete documentation. None were reachable via any current call path, but each was a small robustness/documentation gap.

- **L8 — AHCI `read_sectors`/`write_sectors` input validation** (`kernel/src/drivers/ahci.rs`)
  - Added a self-contained `sector_count == 0` guard to both `read_sectors` and `write_sectors`, mirroring `ata.rs`'s guard style. Unlike ATA (where 0 is a benign "256 sectors" alias treated as a no-op), AHCI task files interpret a zero sector count as a request for the *maximum* transfer size (e.g. 65536 sectors for 48-bit LBA), so it is rejected outright via a new `AhciError::InvalidSectorCount` rather than silently continuing.
  - Replaced the panicking `assert!(prdtl < 44, ...)` in the PRDT fragmentation loop with a returned `AhciError::PrdtOverflow`, plus an upfront check using a new pure helper `max_prdt_entries_for(total_bytes)` that computes the worst-case PRDT entry count for a transfer size. This helper is exposed (`pub`) specifically so it can be exercised directly by unit tests, since `do_transfer`'s hardware path can't be driven end-to-end without a mapped AHCI port (not present in the default QEMU test environment).

- **L15 — Blink-mode no-op documentation** (`kernel/src/console/interface.rs`, `kernel/src/console/framebuffer.rs`)
  - Documented at the `KernelConsole` trait level that `disable_blink_mode`/`enable_blink_mode` are a VGA-attribute-controller-specific concept and are expected to be a silent no-op on non-VGA backends (e.g. `FramebufferConsole`), instead of leaving the contract described purely in VGA terms.
  - Updated the framebuffer's no-op implementations to reference this trait-level contract.

- **L18 — Pause/Break (0xE1) scancode sequence** (`kernel/src/drivers/keyboard.rs`)
  - The Pause key sends a fixed 6-byte make sequence (`E1 1D 45 E1 9D C5`) with no distinct break code. Added a `pause_remaining` counter to `KeyboardState`, set to 5 when the leading `0xE1` byte is seen; each subsequent byte decrements it and is consumed as a no-op instead of falling through to the modifier/ASCII decode path, where the sequence's interior bytes (which alias LCtrl make/break and other codes) could previously be misinterpreted as unrelated key events.

## Test plan
- [x] Added `test_ahci_read_sectors_rejects_zero_sector_count` / `test_ahci_write_sectors_rejects_zero_sector_count` (`kernel/tests/block_test.rs`)
- [x] Added `test_ahci_max_prdt_entries_for_boundary` / `test_ahci_prdt_overflow_guard_condition_trips_for_oversized_transfer` (`kernel/tests/block_test.rs`)
- [x] Added `test_pause_key_scancode_sequence_is_consumed_as_no_op` (`kernel/tests/keyboard_e2e_test.rs`)
- [x] `cargo test` — full suite: **372/372 test cases passed** across 34 test binaries (QEMU-based integration tests)
- [x] `cargo clippy` — zero warnings/errors
- [x] `cargo fmt --check` — clean

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)