### PR TITLE
Boot & console internals cleanup (L12+L13+L14+L17, #62)

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -114,3 +114,6 @@ name = "framebuffer_panic_gate_test"
 
 [[test]]
 name = "test_framework_panic_message_test"
+
+[[test]]
+name = "scroll_dirty_range_test"

--- a/main64/kernel/src/console/framebuffer.rs
+++ b/main64/kernel/src/console/framebuffer.rs
@@ -59,26 +59,26 @@ impl Default for FramebufferConsole {
 impl FramebufferConsole {
     /// Creates and initializes a new FramebufferConsole instance.
     pub fn new() -> Self {
-        let raw = crate::boot_info::BOOT_INFO_PTR.load(core::sync::atomic::Ordering::Relaxed);
-
-        let (cols, rows, fb_info, bb_size) = if raw == 0 {
-            (80, 25, None, 0)
-        } else {
-            // SAFETY: Checked pointer.
-            let bi = unsafe { &*(raw as *const crate::boot_info::BootInfo) };
-            if bi.video_type == crate::boot_info::VideoModeType::Framebuffer
-                && bi.fb_info.base_address != 0
-            {
-                let fb = bi.fb_info;
-                let bb_size = (fb.pixels_per_scanline * fb.height) as usize;
-                (
-                    (fb.width / GLYPH_W) as usize,
-                    (fb.height / GLYPH_H) as usize,
-                    Some(fb),
-                    bb_size,
-                )
-            } else {
-                (80, 25, None, 0)
+        // Re-derive `&BootInfo` through the canonical accessor instead of loading
+        // `BOOT_INFO_PTR` and casting it by hand — `BootInfo::get()` owns the
+        // pointer-validity contract (non-null, `Acquire`-ordered load) in one place.
+        let (cols, rows, fb_info, bb_size) = match crate::boot_info::BootInfo::get() {
+            None => (80, 25, None, 0),
+            Some(bi) => {
+                if bi.video_type == crate::boot_info::VideoModeType::Framebuffer
+                    && bi.fb_info.base_address != 0
+                {
+                    let fb = bi.fb_info;
+                    let bb_size = (fb.pixels_per_scanline * fb.height) as usize;
+                    (
+                        (fb.width / GLYPH_W) as usize,
+                        (fb.height / GLYPH_H) as usize,
+                        Some(fb),
+                        bb_size,
+                    )
+                } else {
+                    (80, 25, None, 0)
+                }
             }
         };
 
@@ -142,6 +142,32 @@ impl FramebufferConsole {
         if y_end > self.dirty_y_max {
             self.dirty_y_max = y_end;
         }
+    }
+
+    /// Computes the scanline range a single-row upward scroll actually touches,
+    /// for a console with `rows` text rows: the `rows - 1` shifted rows plus the
+    /// newly cleared bottom row, i.e. `rows * GLYPH_H` scanlines starting at `0`.
+    ///
+    /// This is deliberately narrower than "the whole framebuffer height" — when
+    /// `fb.height` is not an exact multiple of `GLYPH_H`, there are leftover
+    /// scanlines below the last full text row that `scroll()` never writes to
+    /// and therefore must not be marked dirty (issue #62 / L12: marking them
+    /// dirty forced the RAM-to-RAM backbuffer -> scratch copy in
+    /// `take_flush_job`, still run under `GLOBAL_CONSOLE`'s lock, to cover the
+    /// whole screen instead of just the changed region).
+    fn scroll_dirty_range(rows: usize) -> (u32, u32) {
+        let total_scanlines = rows as u32 * GLYPH_H;
+        (0, total_scanlines.saturating_sub(1))
+    }
+
+    /// Test-only accessor for [`Self::scroll_dirty_range`]. Hidden from public
+    /// docs; lets integration tests confirm the narrowed dirty-range arithmetic
+    /// without needing a live framebuffer console (see `console_flush_lock_test.rs`
+    /// / `scroll_dirty_range_test.rs`).
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn scroll_dirty_range_for_test(rows: usize) -> (u32, u32) {
+        Self::scroll_dirty_range(rows)
     }
 
     /// Writes a single 32-bit pixel value into the RAM backbuffer at coordinates (x, y).
@@ -394,8 +420,13 @@ impl FramebufferConsole {
                 let end_idx = start_idx + GLYPH_H as usize * stride;
                 self.backbuffer[start_idx..end_idx].fill(bg_rgb);
 
-                // Mark the entire screen region dirty to upload the scrolled result
-                self.mark_dirty_range(0, fb.height.saturating_sub(1));
+                // Mark only the scanlines the shift + bottom-row clear above
+                // actually touched dirty (not the whole framebuffer height),
+                // so the RAM-to-RAM backbuffer -> scratch copy that
+                // `take_flush_job` performs under `GLOBAL_CONSOLE`'s lock only
+                // covers the region that really changed (issue #62 / L12).
+                let (dirty_start, dirty_end) = Self::scroll_dirty_range(self.rows);
+                self.mark_dirty_range(dirty_start, dirty_end.min(fb.height.saturating_sub(1)));
             }
 
             // Fix logical cursor row and mark for deferred redraw.

--- a/main64/kernel/src/main.rs
+++ b/main64/kernel/src/main.rs
@@ -5,6 +5,21 @@
 
 #![no_std]
 #![no_main]
+// NOTE (issue #62 / L13): this bin target (`KernelMain`'s crate) declares the
+// same module tree as `lib.rs` via private `mod` declarations rather than
+// depending on the `kaos_kernel` library crate, so every module is compiled
+// twice: once for the library (used by integration tests under `kernel/tests/`)
+// and once for this binary. Many `pub fn`/`pub` items exist solely for the
+// library side (test-only introspection hooks, self-test entry points, trait
+// methods required by `BlockDevice`/`KernelConsole`, etc.) and are never
+// called from `KernelMain`'s own control flow, which makes them look dead
+// specifically in *this* compilation unit. A crate-wide allow is kept
+// (instead of scoping `#[allow(dead_code)]` item-by-item across dozens of
+// unrelated files) because that is where the dead code genuinely lives; the
+// two functions that were truly unused *anywhere* in the codebase
+// (`kernel_va_to_phys`, `kernel_va_to_user_code_va`) have been removed rather
+// than hidden behind this allow (verified via a repo-wide grep with zero
+// remaining callers).
 #![allow(dead_code)]
 
 extern crate alloc;
@@ -32,9 +47,6 @@ use crate::memory::pmm;
 use crate::memory::vmm;
 use drivers::keyboard;
 use drivers::serial;
-
-/// Kernel higher-half base used to translate symbol VAs to physical offsets.
-const KERNEL_HIGHER_HALF_BASE: u64 = 0xFFFF_8000_0000_0000;
 
 /// Zeroes the BSS section using linker-provided boundaries.
 ///
@@ -380,7 +392,16 @@ fn map_framebuffer(boot_info_raw: u64) {
 
     // Configure PAT MSR (0x277) to set PAT1 (bits 8..15) to Write-Combining (0x01).
     // The default value is usually 0x0007_0406_0007_0406 (PAT1 = 0x04 = WT).
-    // SAFETY: Writing to the PAT MSR is safe on x86_64, as we are in Ring 0.
+    // SAFETY:
+    // - Repointing PAT1 to WC is only safe because it is the sole PAT slot ever
+    //   repurposed by this kernel: `map_virtual_to_physical_wc`
+    //   (memory/vmm/mapping.rs) is the only mapping function that sets PWT=1/PCD=0
+    //   on a leaf entry, and it is only ever called for framebuffer pages here.
+    //   No other mapping in the kernel selects PAT1 expecting the default WT
+    //   semantics, so redefining its meaning cannot silently change the caching
+    //   behavior of an unrelated mapping.
+    // - The MSR write itself is architecturally valid only from ring 0, which this
+    //   code always runs in.
     unsafe {
         let mut pat = crate::arch::msr::rdmsr(0x277);
         pat &= !(0xFF << 8); // Clear PAT1
@@ -425,23 +446,4 @@ fn map_framebuffer(boot_info_raw: u64) {
     // `Relaxed` load in the panic path: the flag transitions only `false -> true`, so
     // any observer either sees the fully-mapped framebuffer or safely falls back.
     boot_info::FRAMEBUFFER_MAPPED.store(true, core::sync::atomic::Ordering::Release);
-}
-
-/// Converts higher-half kernel VA to physical address by removing base offset.
-fn kernel_va_to_phys(kernel_va: u64) -> Option<u64> {
-    if kernel_va >= KERNEL_HIGHER_HALF_BASE {
-        Some(kernel_va - KERNEL_HIGHER_HALF_BASE)
-    } else {
-        None
-    }
-}
-
-/// Maps a kernel symbol VA into the configured user code alias window.
-fn kernel_va_to_user_code_va(kernel_va: u64) -> Option<u64> {
-    syscall::user_alias_va_for_kernel(
-        vmm::USER_CODE_BASE,
-        vmm::USER_CODE_SIZE,
-        KERNEL_HIGHER_HALF_BASE,
-        kernel_va,
-    )
 }

--- a/main64/kernel/src/panic.rs
+++ b/main64/kernel/src/panic.rs
@@ -2,12 +2,11 @@
 //!
 //! Required for `no_std` environments.
 
-use crate::boot_info::{framebuffer_panic_writer_available, BootInfo, PixelFormat, BOOT_INFO_PTR};
+use crate::boot_info::{framebuffer_panic_writer_available, BootInfo, PixelFormat};
 use crate::console::FramebufferConsole;
 use crate::drivers::screen::Color;
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use core::sync::atomic::Ordering;
 
 /// Pixel width of a single text glyph (matches the framebuffer console font).
 const GLYPH_W: u32 = 8;
@@ -63,13 +62,11 @@ impl PanicFramebufferWriter {
             return None;
         }
 
-        let raw = BOOT_INFO_PTR.load(Ordering::Relaxed);
-        if raw == 0 {
-            return None;
-        }
-        // SAFETY: `raw` is the boot-info pointer published in `KernelMain` after a
-        // magic check; the structure lives in identity-mapped low memory.
-        let bi = unsafe { &*(raw as *const BootInfo) };
+        // Re-derive the reference through the canonical accessor rather than
+        // re-loading `BOOT_INFO_PTR` and casting it by hand here — `BootInfo::get()`
+        // is the single place that owns the pointer-validity contract (non-null,
+        // `Acquire`-ordered load pairing with the `Release` store in `KernelMain`).
+        let bi = BootInfo::get()?;
         let fb = bi.fb_info;
         Some(Self {
             base: fb.base_address as *mut u32,

--- a/main64/kernel/tests/scroll_dirty_range_test.rs
+++ b/main64/kernel/tests/scroll_dirty_range_test.rs
@@ -1,0 +1,105 @@
+//! Scroll dirty-range narrowing test (issue #62, finding L12).
+//!
+//! Before this fix, `FramebufferConsole::scroll()` marked the *entire*
+//! framebuffer height dirty on every scroll, regardless of how many scanlines
+//! the row-shift + bottom-row-clear actually touched. When the framebuffer's
+//! height is not an exact multiple of the glyph height (`GLYPH_H` = 16), there
+//! are leftover scanlines below the last full text row that `scroll()` never
+//! writes to. Marking those dirty forced `take_flush_job`'s RAM-to-RAM
+//! backbuffer -> scratch copy — which still runs under `GLOBAL_CONSOLE`'s
+//! lock (see issue #16 / `console_flush_lock_test.rs`) — to cover the whole
+//! screen instead of just the changed region.
+//!
+//! This test exercises the pure arithmetic seam
+//! `FramebufferConsole::scroll_dirty_range_for_test`, which computes exactly
+//! the scanline range `scroll()` now marks dirty, without needing a live
+//! console or framebuffer.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+
+use kaos_kernel::console::FramebufferConsole;
+
+/// Entry point for the scroll dirty-range test kernel.
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+
+    test_main();
+
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+/// Panic handler for integration tests.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    kaos_kernel::testing::test_panic_handler(info)
+}
+
+/// Contract: for a console with `rows` text rows (each `GLYPH_H` = 16
+/// scanlines tall), a scroll's dirty range must span exactly `rows * 16`
+/// scanlines starting at `0` — the `rows - 1` shifted rows plus the newly
+/// cleared bottom row — not the framebuffer's full height.
+/// Given: A handful of representative row counts.
+/// When: `scroll_dirty_range_for_test` computes the dirty range for each.
+/// Then: The returned range is exactly `(0, rows * 16 - 1)`.
+/// Failure Impact: A regression here means `scroll()` once again marks
+/// scanlines it never wrote to as dirty, forcing the locked RAM-to-RAM
+/// snapshot copy in `take_flush_job` to cover more of the screen than
+/// actually changed (issue #62 / L12).
+#[test_case]
+fn test_scroll_dirty_range_matches_touched_rows() {
+    kaos_kernel::test_assert!(
+        FramebufferConsole::scroll_dirty_range_for_test(3) == (0, 47),
+        "3 text rows * 16 scanlines/row = 48 scanlines (y = 0..=47)"
+    );
+    kaos_kernel::test_assert!(
+        FramebufferConsole::scroll_dirty_range_for_test(25) == (0, 399),
+        "25 text rows * 16 scanlines/row = 400 scanlines (y = 0..=399)"
+    );
+    kaos_kernel::test_assert!(
+        FramebufferConsole::scroll_dirty_range_for_test(1) == (0, 15),
+        "1 text row * 16 scanlines/row = 16 scanlines (y = 0..=15)"
+    );
+}
+
+/// Contract: the dirty range must never depend on the framebuffer's raw pixel
+/// height — only on the number of text rows. This is exactly the behavior
+/// change from the old code, which used to mark `(0, fb.height - 1)` dirty
+/// even when `fb.height` included scanlines below the last full text row that
+/// no glyph write ever touches.
+/// Given: A framebuffer height that is *not* an exact multiple of `GLYPH_H`
+///   (e.g. 53 px for 3 rows of 16 px = 48 px, leaving 5 leftover scanlines).
+/// When: The dirty range for those 3 rows is computed.
+/// Then: The range stops at `47`, not `52` — the leftover scanlines below the
+///   last full text row are excluded.
+/// Failure Impact: Without this narrowing, every scroll needlessly copies and
+/// (eventually) uploads scanlines that are never rendered to, which is
+/// exactly the residual full-screen locked copy described in issue #62 / L12.
+#[test_case]
+fn test_scroll_dirty_range_excludes_leftover_scanlines_below_last_row() {
+    let rows = 3;
+    let fb_height_with_leftover_scanlines: u32 = rows as u32 * 16 + 5;
+
+    let (start, end) = FramebufferConsole::scroll_dirty_range_for_test(rows);
+
+    kaos_kernel::test_assert!(start == 0, "dirty range must start at scanline 0");
+    kaos_kernel::test_assert!(
+        end == 47,
+        "dirty range must stop at the last scanline of the last full text row (47), \
+         not extend into the leftover scanlines below it"
+    );
+    kaos_kernel::test_assert!(
+        end < fb_height_with_leftover_scanlines - 1,
+        "dirty range must be strictly narrower than (fb.height - 1) when the \
+         framebuffer height is not an exact multiple of GLYPH_H"
+    );
+}

--- a/main64/kernel/tests/vmm_test.rs
+++ b/main64/kernel/tests/vmm_test.rs
@@ -980,7 +980,7 @@ fn test_vmm_contracts_doc_fix_issue_13() {
     // which aligns with the scalar fields lock contract.
     let old = vmm::set_debug_output(true);
     let current = vmm::serial_debug_enabled();
-    assert_eq!(current, true);
+    assert!(current);
     vmm::set_debug_output(old);
 }
 


### PR DESCRIPTION
## Summary

Fixes the four LOW-severity findings from the boot/console internals review (issue #62):

- **L12** — `FramebufferConsole::scroll()` marked the entire framebuffer height dirty on every scroll, so the RAM-to-RAM backbuffer→scratch copy in `take_flush_job` (still run under `GLOBAL_CONSOLE`'s lock) covered the whole screen. Narrowed the dirty range to the scanlines actually touched by the row-shift + bottom-row-clear (`rows * GLYPH_H`), via a new pure helper `FramebufferConsole::scroll_dirty_range`.
- **L13** — `kernel_va_to_phys` and `kernel_va_to_user_code_va` had zero callers anywhere in `kernel/src` or `kernel/tests` (confirmed by repo-wide grep) and are removed, along with the now-unused `KERNEL_HIGHER_HALF_BASE` const. The crate-level `#![allow(dead_code)]` in `main.rs` is kept — `main.rs` compiles the same module tree as `lib.rs` via private `mod` declarations rather than depending on the `kaos_kernel` library crate, so dozens of `pub` items that exist only for the library/integration-test side are genuinely dead code in this compilation unit (verified: removing the allow surfaces ~30 new warnings across unrelated files).
- **L14** — `framebuffer.rs`'s `FramebufferConsole::new()` and `panic.rs`'s `PanicFramebufferWriter::from_boot_info()` both re-derived `&BootInfo` from `BOOT_INFO_PTR` by hand instead of calling the canonical `BootInfo::get()` accessor. Both now call `BootInfo::get()`; the overstated "Checked pointer" comment is replaced with an accurate one.
- **L17** — The PAT MSR write's SAFETY comment justified the write via "ring 0" when the real invariant is that `map_virtual_to_physical_wc` (`memory/vmm/mapping.rs`) is the only mapping function that ever selects PAT1 (PWT=1/PCD=0). Comment updated to state this.

Also fixed a pre-existing `clippy::bool_assert_comparison` warning in `vmm_test.rs` (`assert_eq!(x, true)` → `assert!(x)`), surfaced while verifying a fully clean `cargo clippy --tests`.

## Test plan

- [x] Added `kernel/tests/scroll_dirty_range_test.rs` (2 new test cases) verifying the narrowed dirty-range arithmetic, including the case where framebuffer height is not an exact multiple of `GLYPH_H`.
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` (lib+bin) — clean
- [x] `cargo clippy --tests` — clean
- [x] `cargo test` — full suite passes: **369/369 test cases across 35 test files**

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)