### PR TITLE
L6+L7+L9+L10+L11: IO layer (VFS/FAT32) documentation & consistency gaps

### DIFF
--- a/main64/kernel/src/io/fat32.rs
+++ b/main64/kernel/src/io/fat32.rs
@@ -175,7 +175,10 @@ impl Fat32Volume {
             // Reject clusters outside the volume bounds before translating them to LBAs.
             let cluster_lba = self.cluster_to_lba(current_cluster)?;
             for i in 0..self.sec_per_clus {
-                let mut sector = [0u8; 512];
+                // Size the read buffer from `self.bytes_per_sec` rather than a hardcoded
+                // 512 so this stays correct if `mount()`'s 512-only restriction is ever
+                // relaxed (see the struct field doc comment).
+                let mut sector = alloc::vec![0u8; self.bytes_per_sec as usize];
                 crate::drivers::block::read_sectors(cluster_lba + i as u64, 1, &mut sector)
                     .map_err(Fat32Error::Block)?;
 
@@ -193,7 +196,7 @@ impl Fat32Volume {
                         continue;
                     }
                     let attr = sector[offset + 0x0B];
-                    if attr == 0x0F || attr == 0x08 {
+                    if is_skippable_dir_entry(attr) {
                         // LFN (Long File Name) or Volume ID entry, skip.
                         continue;
                     }
@@ -256,7 +259,10 @@ impl Fat32Volume {
             // Reject clusters outside the volume bounds before translating them to LBAs.
             let cluster_lba = self.cluster_to_lba(current_cluster)?;
             for i in 0..self.sec_per_clus {
-                let mut sector = [0u8; 512];
+                // Size the read buffer from `self.bytes_per_sec` rather than a hardcoded
+                // 512 so this stays correct if `mount()`'s 512-only restriction is ever
+                // relaxed (see the struct field doc comment).
+                let mut sector = alloc::vec![0u8; self.bytes_per_sec as usize];
                 crate::drivers::block::read_sectors(cluster_lba + i as u64, 1, &mut sector)
                     .map_err(Fat32Error::Block)?;
 
@@ -314,7 +320,10 @@ impl Fat32Volume {
                 };
 
                 for i in 0..self.sec_per_clus {
-                    let mut sector = [0u8; 512];
+                    // Size the read buffer from `self.bytes_per_sec` rather than a hardcoded
+                    // 512 so this stays correct if `mount()`'s 512-only restriction is ever
+                    // relaxed (see the struct field doc comment).
+                    let mut sector = alloc::vec![0u8; self.bytes_per_sec as usize];
                     if crate::drivers::block::read_sectors(cluster_lba + i as u64, 1, &mut sector)
                         .is_err()
                     {
@@ -333,7 +342,11 @@ impl Fat32Volume {
                             continue;
                         }
                         let attr = sector[offset + 0x0B];
-                        if attr == 0x0F {
+                        if is_skippable_dir_entry(attr) {
+                            // LFN (Long File Name) or Volume ID entry, skip. Matches the
+                            // filtering already applied by `read_file` (see there) so the
+                            // directory listing doesn't surface pseudo-entries that carry
+                            // no readable file data.
                             continue;
                         }
 
@@ -533,6 +546,44 @@ impl Fat32Volume {
 
         Ok(cluster_count)
     }
+}
+
+/// Test-only wrapper around `is_skippable_dir_entry`.
+///
+/// Hidden from public docs; used by integration tests to verify the shared
+/// LFN/volume-ID filtering logic (L7, #60) without needing a full directory
+/// walk over a real block device.
+#[doc(hidden)]
+pub fn is_skippable_dir_entry_for_test(attr: u8) -> bool {
+    is_skippable_dir_entry(attr)
+}
+
+/// Test-only wrapper around `map_fat32_err`.
+///
+/// Hidden from public docs; used by integration tests to verify that each
+/// distinct `Fat32Error` variant maps to its own `FsError` variant instead of
+/// collapsing into a generic `FsError::Io` (L9, #60).
+#[doc(hidden)]
+pub fn map_fat32_err_for_test(err: Fat32Error) -> crate::io::vfs::FsError {
+    map_fat32_err(err)
+}
+
+/// FAT directory-entry attribute bit for a Volume ID / Volume Label entry.
+const ATTR_VOLUME_ID: u8 = 0x08;
+
+/// FAT directory-entry attribute bit for a Long File Name (LFN) entry.
+const ATTR_LONG_NAME: u8 = 0x0F;
+
+/// Returns whether a directory entry with the given `attr` byte is a
+/// pseudo-entry that must be skipped by any directory walk (LFN continuation
+/// entry or the volume label entry), rather than a real file/subdirectory.
+///
+/// Shared by `read_file` and `print_root_directory` so both directory walks
+/// apply exactly the same filtering; `print_root_directory` previously only
+/// skipped LFN entries and could surface the volume label as a bogus
+/// zero-cluster "file" in the listing.
+fn is_skippable_dir_entry(attr: u8) -> bool {
+    attr == ATTR_LONG_NAME || attr == ATTR_VOLUME_ID
 }
 
 /// Helper to convert a file name to the 11-byte space-padded uppercase 8.3 form.
@@ -756,12 +807,22 @@ impl crate::io::vfs::FileSystem for Fat32Fs {
 }
 
 /// Translate FAT32 errors into VFS FsError variants.
+///
+/// Each distinct `Fat32Error` maps to its own `FsError` variant so callers
+/// (syscall dispatch, the program loader) can tell e.g. "tried to read a
+/// directory as a file" (`IsDirectory`) apart from "the on-disk FAT chain is
+/// corrupt" (`BadChain`) instead of both collapsing into a generic `Io` error
+/// that loses that diagnostic information.
 fn map_fat32_err(err: Fat32Error) -> crate::io::vfs::FsError {
     match err {
         Fat32Error::NotFound => crate::io::vfs::FsError::NotFound,
+        Fat32Error::NotFat32 => crate::io::vfs::FsError::NotFat32,
+        Fat32Error::IsDirectory => crate::io::vfs::FsError::IsDirectory,
+        Fat32Error::BadChain => crate::io::vfs::FsError::BadChain,
+        Fat32Error::TooLarge => crate::io::vfs::FsError::TooLarge,
         Fat32Error::Block(crate::drivers::block::BlockError::Unsupported) => {
             crate::io::vfs::FsError::Unsupported
         }
-        _ => crate::io::vfs::FsError::Io,
+        Fat32Error::Block(_) => crate::io::vfs::FsError::Io,
     }
 }

--- a/main64/kernel/src/io/vfs.rs
+++ b/main64/kernel/src/io/vfs.rs
@@ -21,6 +21,16 @@ pub enum FsError {
     Io,
     /// The provided filename is invalid or cannot be parsed.
     InvalidName,
+    /// The mounted volume does not conform to the filesystem's expected on-disk
+    /// structure (e.g. a bad boot-sector signature or an unsupported geometry).
+    NotFat32,
+    /// The requested name resolves to a directory, not a readable file.
+    IsDirectory,
+    /// A loop or structurally invalid entry was encountered while following the
+    /// on-disk allocation chain for a file or directory.
+    BadChain,
+    /// The requested file exceeds the backend's defensively defined maximum size.
+    TooLarge,
 }
 
 /// File opening mode.
@@ -32,23 +42,56 @@ pub enum FileMode {
 }
 
 /// Operations the syscall layer + loader need. Writes may return `Unsupported`.
+///
+/// # Fd-ownership contract (MUST)
+///
+/// File descriptors are not globally shared: each fd is created by `open()` on
+/// behalf of the calling task and is only valid for that task afterwards. Every
+/// method below that takes an `fd` **MUST** verify, before performing the
+/// operation, that `fd` was opened by the task currently identified by
+/// `crate::scheduler::current_task_id()` — and return `FsError::InvalidFd`
+/// (the same error used for an unknown/closed fd) if it was opened by a
+/// different task. This holds for `close`, `read`, `write`, `seek`, and `eof`.
+///
+/// This check is part of the trait's contract rather than something the VFS
+/// facade (`with()`/the free functions below) enforces on the caller's behalf:
+/// the facade just forwards the fd to the mounted backend. A backend that
+/// omits the ownership check would silently allow one task to read, seek, or
+/// close file descriptors belonging to another task. The in-tree FAT32
+/// backend (`Fat32Fs` in `io/fat32.rs`) enforces this per-call; any future
+/// second backend implementing `FileSystem` MUST do the same.
 pub trait FileSystem: Send + Sync {
     /// Open a file by name. Returns the file descriptor index.
     fn open(&self, name: &str, mode: FileMode) -> Result<usize, FsError>;
 
     /// Close an active file descriptor.
+    ///
+    /// MUST reject `fd` with `FsError::InvalidFd` if it is not owned by the
+    /// calling task (see the fd-ownership contract on this trait).
     fn close(&self, fd: usize) -> Result<(), FsError>;
 
     /// Read data from an active file descriptor. Returns the number of bytes read.
+    ///
+    /// MUST reject `fd` with `FsError::InvalidFd` if it is not owned by the
+    /// calling task (see the fd-ownership contract on this trait).
     fn read(&self, fd: usize, buf: &mut [u8]) -> Result<usize, FsError>;
 
     /// Write data to an active file descriptor. Returns the number of bytes written.
+    ///
+    /// MUST reject `fd` with `FsError::InvalidFd` if it is not owned by the
+    /// calling task (see the fd-ownership contract on this trait).
     fn write(&self, fd: usize, buf: &[u8]) -> Result<usize, FsError>;
 
     /// Adjust the offset cursor of an active file descriptor.
+    ///
+    /// MUST reject `fd` with `FsError::InvalidFd` if it is not owned by the
+    /// calling task (see the fd-ownership contract on this trait).
     fn seek(&self, fd: usize, offset: u32) -> Result<(), FsError>;
 
     /// Return whether the offset cursor has reached or passed the end of the file.
+    ///
+    /// MUST reject `fd` with `FsError::InvalidFd` if it is not owned by the
+    /// calling task (see the fd-ownership contract on this trait).
     fn eof(&self, fd: usize) -> Result<bool, FsError>;
 
     /// Delete a file by name.
@@ -205,6 +248,18 @@ pub fn close_task_fds(task_id: usize) {
 /// `with()` call is in flight only drops the global slot's `Arc` handle — the
 /// clone held by the in-flight closure keeps the filesystem allocation alive
 /// until that closure returns.
+///
+/// Residual caveat (not a memory-safety issue, but a logical foot-gun): this
+/// function is intentionally ungated (no `#[cfg(test)]`) for the reasons
+/// above, so nothing at the type level stops production code from calling it.
+/// Doing so while another task's `with()` call is in flight does not corrupt
+/// memory, but it does unmount the filesystem out from under that in-flight
+/// operation's *subsequent* facade calls (e.g. a task mid-`read_file` that
+/// then calls `open` again would see `FsError::NotMounted`), and any later
+/// `mount()` call is a no-op only relative to whatever got mounted last. This
+/// function must therefore only ever be called from single-threaded test
+/// setup/teardown, never from a code path reachable while the kernel is
+/// otherwise running.
 #[doc(hidden)]
 pub fn reset_mounted_fs() {
     *MOUNTED_FS.lock() = None;

--- a/main64/kernel/src/process/loader.rs
+++ b/main64/kernel/src/process/loader.rs
@@ -303,9 +303,14 @@ fn map_fs_error(error: FsError) -> ExecError {
     match error {
         FsError::InvalidName => ExecError::InvalidName,
         FsError::NotFound => ExecError::NotFound,
-        FsError::Unsupported | FsError::NotMounted | FsError::InvalidFd | FsError::Io => {
-            ExecError::Io
-        }
+        FsError::Unsupported
+        | FsError::NotMounted
+        | FsError::InvalidFd
+        | FsError::Io
+        | FsError::NotFat32
+        | FsError::IsDirectory
+        | FsError::BadChain
+        | FsError::TooLarge => ExecError::Io,
     }
 }
 

--- a/main64/kernel/tests/fat32_test.rs
+++ b/main64/kernel/tests/fat32_test.rs
@@ -10,7 +10,9 @@
 
 use core::panic::PanicInfo;
 use kaos_kernel::drivers::block;
+use kaos_kernel::drivers::block::BlockError;
 use kaos_kernel::io::fat32;
+use kaos_kernel::io::vfs::FsError;
 
 /// Entry point for the integration test kernel.
 #[no_mangle]
@@ -143,4 +145,148 @@ fn test_cyclic_fat_chain_returns_bad_chain_within_cluster_count() {
         "a cyclic FAT chain must be reported as BadChain instead of looping forever, got {:?}",
         result
     );
+}
+
+/// Contract (L7, #60): directory walks must skip both LFN continuation entries
+/// (attr == 0x0F) and the volume-label entry (attr == 0x08), the same filtering
+/// `read_file` already applied. `print_root_directory` previously only checked
+/// for 0x0F and could surface the volume label as a bogus zero-size, zero-cluster
+/// "file" in its listing.
+/// Given: The shared `is_skippable_dir_entry` predicate used by both directory
+/// walks (exposed for tests via `is_skippable_dir_entry_for_test`).
+/// When: It is evaluated against the LFN attribute, the volume-ID attribute, and
+/// a representative set of "real" entry attributes (plain file, read-only file,
+/// subdirectory).
+/// Then: Only the LFN and volume-ID attributes are reported as skippable.
+#[test_case]
+fn test_is_skippable_dir_entry_skips_lfn_and_volume_id_only() {
+    // LFN continuation entry: must be skipped.
+    assert!(fat32::is_skippable_dir_entry_for_test(0x0F));
+    // Volume label entry: must be skipped (this is the L7 fix itself).
+    assert!(fat32::is_skippable_dir_entry_for_test(0x08));
+
+    // A plain file entry must not be treated as skippable.
+    assert!(!fat32::is_skippable_dir_entry_for_test(0x00));
+    // A read-only file entry must not be treated as skippable.
+    assert!(!fat32::is_skippable_dir_entry_for_test(0x01));
+    // A subdirectory entry must not be treated as skippable (it is handled
+    // separately via the `ATTR_DIRECTORY` bit further down the walk).
+    assert!(!fat32::is_skippable_dir_entry_for_test(0x10));
+    // An archive-bit-only file entry must not be treated as skippable.
+    assert!(!fat32::is_skippable_dir_entry_for_test(0x20));
+}
+
+/// Contract (L9, #60): `map_fat32_err` must translate each distinct
+/// `Fat32Error` variant into its own `FsError` variant, instead of collapsing
+/// `NotFat32`/`IsDirectory`/`BadChain`/`TooLarge` into a generic `FsError::Io`
+/// and losing which specific failure occurred.
+/// Given: One representative value of every `Fat32Error` variant, including
+/// both `Fat32Error::Block` sub-cases (the "unsupported operation" case, which
+/// intentionally still maps to `FsError::Unsupported`, and a generic transport
+/// failure, which maps to `FsError::Io`).
+/// When: Each is passed through `map_fat32_err` (exposed for tests via
+/// `map_fat32_err_for_test`).
+/// Then: Each produces a distinct, specific `FsError` variant rather than all
+/// non-`NotFound`/`Unsupported` cases collapsing into `FsError::Io`.
+#[test_case]
+fn test_map_fat32_err_preserves_distinct_error_variants() {
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::NotFound),
+        FsError::NotFound
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::NotFat32),
+        FsError::NotFat32
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::IsDirectory),
+        FsError::IsDirectory
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::BadChain),
+        FsError::BadChain
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::TooLarge),
+        FsError::TooLarge
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::Block(BlockError::Unsupported)),
+        FsError::Unsupported
+    ));
+    assert!(matches!(
+        fat32::map_fat32_err_for_test(fat32::Fat32Error::Block(BlockError::Device)),
+        FsError::Io
+    ));
+}
+
+/// Contract (L10, #60): `Fat32Volume::mount` must keep rejecting BPBs whose
+/// `BytesPerSec` field is not exactly 512 as `Fat32Error::NotFat32`. This is
+/// the invariant that makes the sector-size buffers throughout `fat32.rs` safe
+/// to size from `self.bytes_per_sec` (see `read_file`/`print_root_directory`):
+/// as long as `mount()` keeps enforcing 512, `self.bytes_per_sec` is always
+/// 512 in practice, so switching those buffers from a hardcoded `512` literal
+/// to `self.bytes_per_sec` is behavior-preserving for every volume that can
+/// actually mount.
+/// Given: A synthetic BPB sector at a scratch LBA, identical to a valid FAT32
+/// boot sector except `BytesPerSec` (offset 0x0B) is set to 1024 instead of 512.
+/// When: `Fat32Volume::mount` is called against that scratch LBA.
+/// Then: It must return `Err(Fat32Error::NotFat32)` rather than mounting a
+/// volume whose declared sector size disagrees with the buffers the rest of
+/// the module allocates.
+#[test_case]
+fn test_mount_rejects_non_512_byte_sector() {
+    // Step 1: The ATA block device is already initialized by
+    // `test_cyclic_fat_chain_returns_bad_chain_within_cluster_count`, which
+    // the test harness runs before this test (test cases run in a fixed,
+    // alphabetically-sorted order within a binary). Re-running `pmm::init`/
+    // `vmm::init`/`heap::init` here would re-initialize live kernel memory
+    // management state from under the current test process, which is not a
+    // supported operation, so this test intentionally reuses the already-
+    // initialized ATA device instead of repeating that setup.
+    if !kaos_kernel::memory::pmm::is_initialized() {
+        kaos_kernel::memory::pmm::init(false);
+        kaos_kernel::arch::interrupts::init();
+        kaos_kernel::memory::vmm::init(false);
+        kaos_kernel::memory::heap::init(false);
+        kaos_kernel::drivers::ata::init();
+        block::init_ata();
+    }
+
+    // Step 2: Pick a scratch LBA far past the real FAT32 filesystem built by
+    // `tests/test_runner.sh`, so this synthetic boot sector cannot collide
+    // with (or corrupt) the volume other integration tests mount.
+    const SCRATCH_BOOT_LBA: u64 = 125_500;
+
+    // Step 3: Craft a boot sector that is a valid FAT32 BPB in every respect
+    // except `BytesPerSec`, which is set to 1024 instead of the required 512.
+    let mut sector = [0u8; 512];
+    sector[0x0B..0x0D].copy_from_slice(&1024u16.to_le_bytes()); // BytesPerSec = 1024
+    sector[0x0D] = 1; // SecPerClus
+    sector[0x0E..0x10].copy_from_slice(&32u16.to_le_bytes()); // RsvdSecCnt
+    sector[0x10] = 2; // NumFATs
+    sector[0x11..0x13].copy_from_slice(&0u16.to_le_bytes()); // RootEntCnt = 0 (FAT32)
+    sector[0x13..0x15].copy_from_slice(&0u16.to_le_bytes()); // TotSec16 = 0 (FAT32)
+    sector[0x16..0x18].copy_from_slice(&0u16.to_le_bytes()); // FATSz16 = 0 (FAT32)
+    sector[0x20..0x24].copy_from_slice(&131_072u32.to_le_bytes()); // TotSec32
+    sector[0x24..0x28].copy_from_slice(&1000u32.to_le_bytes()); // FATSz32
+    sector[0x2C..0x30].copy_from_slice(&2u32.to_le_bytes()); // RootCluster
+    sector[0x1FE..0x200].copy_from_slice(&0xAA55u16.to_le_bytes()); // Boot signature
+
+    block::write_sectors(SCRATCH_BOOT_LBA, 1, &sector)
+        .expect("writing the synthetic 1024-byte-sector BPB must succeed");
+
+    // Step 4: Attempt to mount it and confirm the 512-byte-sector gate rejects it.
+    // `Fat32Volume` does not implement `Debug`, so on mismatch we report only
+    // whether an `Ok(_)` (unexpectedly mounted) or the wrong `Err` variant was
+    // returned, without trying to print the volume itself.
+    let result = fat32::Fat32Volume::mount(SCRATCH_BOOT_LBA);
+    match result {
+        Err(fat32::Fat32Error::NotFat32) => {}
+        Err(other) => panic!(
+            "mount() must reject a non-512-byte-sector BPB as NotFat32, got Err({:?})",
+            other
+        ),
+        Ok(_) => panic!("mount() must reject a non-512-byte-sector BPB as NotFat32, got Ok(_)"),
+    }
 }


### PR DESCRIPTION
## Summary

Fixes five LOW-severity findings from the IO-layer review, all in `kernel/src/io/vfs.rs` and `kernel/src/io/fat32.rs`:

- **L6** — Fd-ownership check was only enforced inside the FAT32 backend, not documented as a contract of the `FileSystem` trait. Added an explicit `# Fd-ownership contract (MUST)` doc section on the trait, plus a per-method note on every fd-taking method, so any future second backend can't silently omit the check.
- **L7** — `print_root_directory` only skipped LFN (`0x0F`) entries, unlike `read_file` which already skipped both LFN and `ATTR_VOLUME_ID` (`0x08`). Factored the filtering into a shared `is_skippable_dir_entry(attr)` helper used by both directory walks, so the root listing no longer surfaces the volume label as a bogus zero-cluster "file".
- **L9** — `map_fat32_err` collapsed `NotFat32`/`IsDirectory`/`BadChain`/`TooLarge` into a generic `FsError::Io`. Added dedicated `FsError` variants for each and updated `map_fat32_err` to preserve them; updated the loader's exhaustive `match` over `FsError` to keep it exhaustive (mapped to `ExecError::Io`, same as before, since the loader doesn't need finer granularity there).
- **L10** — Several sector-read buffers in `read_file` and `print_root_directory` were hardcoded to `[0u8; 512]` instead of being sized from `self.bytes_per_sec`, unlike `next_cluster` which already did this correctly. Made all three sites consistent with `next_cluster`'s approach.
- **L11** — `reset_mounted_fs()` remains intentionally ungated (needed for test isolation), but had no documentation of the residual (non-memory-safety) foot-gun of calling it while a `with()` call is in flight. Added an explicit doc-comment caveat.

## Tests

- `test_is_skippable_dir_entry_skips_lfn_and_volume_id_only` (L7): verifies the shared filter skips exactly LFN/volume-ID attrs and nothing else.
- `test_map_fat32_err_preserves_distinct_error_variants` (L9): verifies every `Fat32Error` variant maps to its own distinct `FsError`, not a collapsed `Io`.
- `test_mount_rejects_non_512_byte_sector` (L10): verifies `mount()` still rejects a synthetic BPB with `BytesPerSec = 1024`, the invariant that makes sizing buffers from `self.bytes_per_sec` behavior-preserving.

L6 and L11 are documentation-only changes (no behavior change), so no new test was required for those per the project's test policy.

## Test plan

- [x] `cargo build` (kernel crate) succeeds
- [x] `cargo fmt --check` clean (workspace)
- [x] `cargo clippy -- -D warnings` clean (kernel lib + affected test binaries)
- [x] `cargo test` — all 370 test cases across 34 integration-test binaries pass, including the 3 new cases in `fat32_test`

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)