### PR TITLE
Deduplicate the 4-level page-table walk in the VMM (#58)

### DIFF
--- a/main64/kernel/src/memory/vmm/diagnostics.rs
+++ b/main64/kernel/src/memory/vmm/diagnostics.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
 use super::page_table::{
-    page_align_down, pd_index, pd_table_addr, pdp_index, pdp_table_addr, pml4_index,
-    pt_for_if_present, pt_index, pt_table_addr, table_at, table_entry, PML4_TABLE_ADDR,
+    page_align_down, pt_for_if_present, pt_index, table_entry, walk_levels, WalkResult,
 };
 use super::{read_virt_u8, unmap_virtual_address, vmm_logln, write_virt_u8};
 
@@ -12,32 +11,16 @@ use super::{read_virt_u8, unmap_virtual_address, vmm_logln, write_virt_u8};
 pub fn debug_table_pfns_for_va(virtual_address: u64) -> Option<(u64, u64, u64)> {
     // Diagnostics always inspect page-aligned address.
     let virtual_address = page_align_down(virtual_address);
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4_idx = pml4_index(virtual_address);
-    let pml4e = table_entry(pml4, pml4_idx);
 
-    if !pml4e.present() || pml4e.huge() {
-        return None;
+    // Delegate the PML4/PDP/PD bail sequence to the shared walk; the PML4
+    // huge-page check is not part of `walk_levels` itself (see its doc
+    // comment), so it is still applied here to preserve exact behavior.
+    match walk_levels(virtual_address) {
+        WalkResult::Resolved {
+            pml4e, pdpe, pde, ..
+        } if !pml4e.huge() => Some((pml4e.frame(), pdpe.frame(), pde.frame())),
+        _ => None,
     }
-
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdp_idx = pdp_index(virtual_address);
-    let pdpe = table_entry(pdp, pdp_idx);
-
-    if !pdpe.present() || pdpe.huge() {
-        return None;
-    }
-
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pd_idx = pd_index(virtual_address);
-    let pde = table_entry(pd, pd_idx);
-
-    if !pde.present() || pde.huge() {
-        return None;
-    }
-
-    // Return intermediate table frame numbers for caller-side inspection.
-    Some((pml4e.frame(), pdpe.frame(), pde.frame()))
 }
 
 /// Returns the mapped leaf PFN for `virtual_address` in active CR3.
@@ -63,33 +46,23 @@ pub fn debug_mapped_pfn_for_va(virtual_address: u64) -> Option<u64> {
 pub fn debug_mapping_flags_for_va(virtual_address: u64) -> Option<(bool, bool, bool, bool, bool)> {
     // Diagnostics always inspect page-aligned address.
     let virtual_address = page_align_down(virtual_address);
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4_idx = pml4_index(virtual_address);
-    let pml4e = table_entry(pml4, pml4_idx);
 
-    if !pml4e.present() || pml4e.huge() {
+    // Resolve the shared path down to the leaf PT, then apply the same PML4
+    // huge-page defensive check the other diagnostics helpers use.
+    let WalkResult::Resolved {
+        pml4e,
+        pdpe,
+        pde,
+        pt,
+    } = walk_levels(virtual_address)
+    else {
+        return None;
+    };
+    if pml4e.huge() {
         return None;
     }
 
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdp_idx = pdp_index(virtual_address);
-    let pdpe = table_entry(pdp, pdp_idx);
-
-    if !pdpe.present() || pdpe.huge() {
-        return None;
-    }
-
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pd_idx = pd_index(virtual_address);
-    let pde = table_entry(pd, pd_idx);
-
-    if !pde.present() || pde.huge() {
-        return None;
-    }
-
-    let pt = table_at(pt_table_addr(virtual_address));
     let pte = table_entry(pt, pt_index(virtual_address));
-
     if !pte.present() {
         return None;
     }

--- a/main64/kernel/src/memory/vmm/mapping.rs
+++ b/main64/kernel/src/memory/vmm/mapping.rs
@@ -5,8 +5,8 @@ use crate::memory::pmm;
 use super::page_table::{
     alloc_frame_phys, alloc_frame_phys_or_panic, entry_ptr, invlpg, page_align_down, pd_index,
     pd_table_addr, pdp_index, pdp_table_addr, phys_to_pfn, pml4_index, pt_for_if_present, pt_index,
-    pt_table_addr, read_cr3, table_at, table_entry, table_is_empty, table_zero, write_cr3,
-    PML4_TABLE_ADDR,
+    pt_table_addr, read_cr3, table_at, table_entry, table_is_empty, table_zero, walk_levels,
+    write_cr3, PageTable, WalkResult, PML4_TABLE_ADDR,
 };
 use super::{
     classify_user_region, debug_alloc, vmm_logln, UserRegion, TEMP_CLONE_PML4_VA,
@@ -151,44 +151,77 @@ pub fn populate_page_table_path(virtual_address: u64, user: bool) -> Result<(), 
     Ok(())
 }
 
-/// Clears one mapped leaf page and prunes empty page-table levels for `virtual_address`.
+/// Bundles the already-resolved tables and indices for one virtual address's
+/// PML4/PDP/PD/PT path, as produced by a successful [`walk_levels`] resolution.
 ///
-/// This helper is used by address-space teardown paths and intentionally does
-/// not log warnings when a leaf PFN is not PMM-managed.
+/// Grouping these together (instead of passing eight raw pointers/indices
+/// around individually) keeps [`clear_leaf_and_prune`] a plain 3-argument
+/// function and gives the shared-path callers in [`unmap_page_and_prune_pagetable_hierarchy`]
+/// and [`reclaim_user_range`] one obvious place to construct it from the
+/// pointers they compute (cheaply, via [`table_at`] + the `*_table_addr`
+/// helpers) once `walk_levels` confirms the path resolves.
+struct ResolvedPath {
+    pml4: *mut PageTable,
+    pml4_idx: usize,
+    pdp: *mut PageTable,
+    pdp_idx: usize,
+    pd: *mut PageTable,
+    pd_idx: usize,
+    pt: *mut PageTable,
+}
+
+impl ResolvedPath {
+    /// Recomputes the table pointers/indices for `virtual_address`.
+    ///
+    /// Callers must already know the path resolves (e.g. `walk_levels`
+    /// returned `WalkResult::Resolved` for this address) -- recomputation
+    /// here is pure address arithmetic (`table_at` + the `*_table_addr`
+    /// helpers), not a fresh page-table read, so this does not reintroduce
+    /// the redundant walk this refactor removes.
+    fn for_virtual_address(virtual_address: u64) -> Self {
+        Self {
+            pml4: table_at(PML4_TABLE_ADDR),
+            pml4_idx: pml4_index(virtual_address),
+            pdp: table_at(pdp_table_addr(virtual_address)),
+            pdp_idx: pdp_index(virtual_address),
+            pd: table_at(pd_table_addr(virtual_address)),
+            pd_idx: pd_index(virtual_address),
+            pt: table_at(pt_table_addr(virtual_address)),
+        }
+    }
+}
+
+/// Clears the leaf PTE for `virtual_address` in an *already-resolved* 4-level
+/// `path` and prunes now-empty PD/PDP/PML4 levels bottom-up.
 ///
-/// If `release_leaf_pfn` is `true`, the leaf PFN is returned to PMM.
-/// If `false`, the leaf mapping is only cleared.
-pub fn unmap_page_and_prune_pagetable_hierarchy(virtual_address: u64, release_leaf_pfn: bool) {
-    let virtual_address = page_align_down(virtual_address);
-
-    // Step 1: Resolve the full 4-level path for `virtual_address`.
-    // If any intermediate level is missing (or huge-mapped), there is no
-    // normal 4KiB leaf to clear and therefore nothing to prune.
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4_idx = pml4_index(virtual_address);
-    let pml4e = table_entry(pml4, pml4_idx);
-    if !pml4e.present() || pml4e.huge() {
-        return;
-    }
-
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdp_idx = pdp_index(virtual_address);
-    let pdpe = table_entry(pdp, pdp_idx);
-    if !pdpe.present() || pdpe.huge() {
-        return;
-    }
-
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pd_idx = pd_index(virtual_address);
-    let pde = table_entry(pd, pd_idx);
-    if !pde.present() || pde.huge() {
-        return;
-    }
-
-    let pt = table_at(pt_table_addr(virtual_address));
+/// This is the shared tail end of both [`unmap_page_and_prune_pagetable_hierarchy`]
+/// (which resolves the path itself via [`walk_levels`]) and [`reclaim_user_range`]
+/// (whose scanning loop has already resolved the same path one level at a time
+/// while deciding how far to descend, and passes the tables/indices straight
+/// through instead of re-walking from PML4 for every present page -- see
+/// issue #58, finding L1).
+///
+/// Callers must guarantee `path` was built for `virtual_address` and that its
+/// PML4/PDP/PD entries are present and non-huge (as [`WalkResult::Resolved`]
+/// guarantees).
+///
+/// If `release_leaf_pfn` is `true`, the leaf PFN is returned to PMM. If
+/// `false`, the leaf mapping is only cleared. This helper is used by
+/// address-space teardown paths and intentionally does not log warnings when
+/// a leaf PFN is not PMM-managed.
+fn clear_leaf_and_prune(virtual_address: u64, path: ResolvedPath, release_leaf_pfn: bool) {
+    let ResolvedPath {
+        pml4,
+        pml4_idx,
+        pdp,
+        pdp_idx,
+        pd,
+        pd_idx,
+        pt,
+    } = path;
     let pt_idx = pt_index(virtual_address);
 
-    // Step 2: Clear the leaf PTE.
+    // Step 1: Clear the leaf PTE.
     // Optionally release the old leaf PFN depending on caller policy:
     // - true  => regular owned user page, return frame to PMM
     // - false => alias/scratch mapping, only remove mapping
@@ -203,7 +236,7 @@ pub fn unmap_page_and_prune_pagetable_hierarchy(virtual_address: u64, release_le
         }
     }
 
-    // Step 3: Bottom-up pruning.
+    // Step 2: Bottom-up pruning.
     // Only remove a parent-table entry if the child table became empty.
     // This guarantees we never drop shared siblings.
     if !table_is_empty(pt.cast_const()) {
@@ -238,6 +271,32 @@ pub fn unmap_page_and_prune_pagetable_hierarchy(virtual_address: u64, release_le
     unsafe { (*entry_ptr(pml4, pml4_idx)).clear() };
     invlpg(pdp_table_addr(virtual_address));
     let _ = pmm::with_pmm(|mgr| mgr.release_pfn(pdp_pfn));
+}
+
+/// Clears one mapped leaf page and prunes empty page-table levels for `virtual_address`.
+///
+/// This helper is used by address-space teardown paths and intentionally does
+/// not log warnings when a leaf PFN is not PMM-managed.
+///
+/// If `release_leaf_pfn` is `true`, the leaf PFN is returned to PMM.
+/// If `false`, the leaf mapping is only cleared.
+pub fn unmap_page_and_prune_pagetable_hierarchy(virtual_address: u64, release_leaf_pfn: bool) {
+    let virtual_address = page_align_down(virtual_address);
+
+    // Resolve the full 4-level path for `virtual_address` through the shared
+    // walk. If any intermediate level is missing (or huge-mapped), there is
+    // no normal 4 KiB leaf to clear and therefore nothing to prune.
+    let WalkResult::Resolved { .. } = walk_levels(virtual_address) else {
+        return;
+    };
+
+    // `walk_levels` already confirmed every level is present and non-huge, so
+    // recomputing the table pointers/indices here is pure address arithmetic
+    // (no additional page-table reads) -- `clear_leaf_and_prune` needs the
+    // raw mutable pointers to prune entries, which `WalkResult` intentionally
+    // does not carry (see its doc comment).
+    let path = ResolvedPath::for_virtual_address(virtual_address);
+    clear_leaf_and_prune(virtual_address, path, release_leaf_pfn);
 }
 
 /// Maps `virtual_address` to `physical_address` with present + writable flags.
@@ -726,12 +785,28 @@ pub fn unmap_user_heap_region() {
 
 /// Reclaims every present user leaf mapping in `[scan_start, scan_end)`.
 ///
-/// Walks the 4-level page-table hierarchy, skipping non-present sub-trees at
-/// the largest granularity possible (512 GiB / 1 GiB / 2 MiB jumps) so large
-/// unmapped gaps are cheap to pass over, and releases each present leaf frame
-/// via the refcounted `PhysicalMemoryManager::release_pfn` while pruning
-/// now-empty PT/PD/PDP levels — the same technique `unmap_user_heap_region`
-/// has always used for the heap window, generalized to arbitrary bounds.
+/// Walks the 4-level page-table hierarchy via the shared [`walk_levels`],
+/// skipping non-present (or huge-mapped) sub-trees at the largest granularity
+/// possible (512 GiB / 1 GiB / 2 MiB jumps) so large unmapped gaps are cheap
+/// to pass over, and releases each present leaf frame via the refcounted
+/// `PhysicalMemoryManager::release_pfn` while pruning now-empty PT/PD/PDP
+/// levels — the same technique `unmap_user_heap_region` has always used for
+/// the heap window, generalized to arbitrary bounds.
+///
+/// For each present page this loop has *already* resolved the PML4/PDP/PD
+/// path while deciding not to skip past it, so the present-page case feeds
+/// those already-resolved tables/indices straight into
+/// [`clear_leaf_and_prune`] instead of re-entering the full 4-level walk per
+/// page through [`unmap_page_and_prune_pagetable_hierarchy`] — see issue #58,
+/// finding L1 (this used to walk the hierarchy twice per reclaimed page).
+///
+/// Note: user mappings are only ever created as 4 KiB pages (see
+/// [`map_user_page`]), so a huge PDP/PD entry is never expected inside the
+/// user scan range in practice; treating it the same as "not present" here
+/// (skip past it at its native granularity) keeps this loop's bail
+/// conditions consistent with every other walk in the VMM instead of
+/// silently misinterpreting a huge page's data frame as a child table
+/// address, which the pre-#58 version of this loop did not guard against.
 ///
 /// Callers must ensure the target address space is already active (e.g. via
 /// [`with_address_space`]) so recursive-mapping helper addresses resolve
@@ -741,39 +816,27 @@ pub fn unmap_user_heap_region() {
 fn reclaim_user_range(scan_start: u64, scan_end: u64) {
     let mut va = scan_start;
     while va < scan_end {
-        // Step 1: Resolve PML4 level and skip if non-present.
-        let pml4 = table_at(PML4_TABLE_ADDR);
-        let pml4_idx = pml4_index(va);
-        let pml4e = table_entry(pml4, pml4_idx);
-        if !pml4e.present() {
-            // PML4 entries cover 512 GiB of virtual address space.
-            va = (va + 0x80_0000_0000) & !(0x80_0000_0000 - 1);
-            continue;
+        match walk_levels(va) {
+            WalkResult::Pml4Missing => {
+                // PML4 entries cover 512 GiB of virtual address space.
+                va = (va + 0x80_0000_0000) & !(0x80_0000_0000 - 1);
+            }
+            WalkResult::PdpMissing { .. } | WalkResult::PdpHuge { .. } => {
+                // PDPT entries cover 1 GiB of virtual address space.
+                va = (va + 0x4000_0000) & !(0x4000_0000 - 1);
+            }
+            WalkResult::PdMissing { .. } | WalkResult::PdHuge { .. } => {
+                // PD entries cover 2 MiB of virtual address space.
+                va = (va + 0x20_0000) & !(0x20_0000 - 1);
+            }
+            WalkResult::Resolved { .. } => {
+                // Page table level exists; reuse the already-resolved path to
+                // clear and prune this one page, then advance by page size.
+                let path = ResolvedPath::for_virtual_address(va);
+                clear_leaf_and_prune(va, path, true);
+                va += PAGE_SIZE_U64;
+            }
         }
-
-        // Step 2: Resolve PDPT level and skip if non-present.
-        let pdp = table_at(pdp_table_addr(va));
-        let pdp_idx = pdp_index(va);
-        let pdpe = table_entry(pdp, pdp_idx);
-        if !pdpe.present() {
-            // PDPT entries cover 1 GiB of virtual address space.
-            va = (va + 0x4000_0000) & !(0x4000_0000 - 1);
-            continue;
-        }
-
-        // Step 3: Resolve PD level and skip if non-present.
-        let pd = table_at(pd_table_addr(va));
-        let pd_idx = pd_index(va);
-        let pde = table_entry(pd, pd_idx);
-        if !pde.present() {
-            // PD entries cover 2 MiB of virtual address space.
-            va = (va + 0x20_0000) & !(0x20_0000 - 1);
-            continue;
-        }
-
-        // Step 4: Page table level exists; unmap individual page and advance by page size.
-        unmap_page_and_prune_pagetable_hierarchy(va, true);
-        va += PAGE_SIZE_U64;
     }
 }
 
@@ -884,55 +947,51 @@ pub fn configure_wc_mapping(start_va: u64, size: u64) {
     let end = page_align_down(start_va + size + PAGE_SIZE_U64 - 1);
 
     while addr < end {
-        let pml4 = table_at(PML4_TABLE_ADDR);
-        let pml4_idx = pml4_index(addr);
-        let pml4e = table_entry(pml4, pml4_idx);
-        if !pml4e.present() {
-            addr += PAGE_SIZE_U64;
-            continue;
-        }
-
-        let pdp = table_at(pdp_table_addr(addr));
-        let pdp_idx = pdp_index(addr);
-        let pdpe = table_entry(pdp, pdp_idx);
-        if !pdpe.present() {
-            addr += PAGE_SIZE_U64;
-            continue;
-        }
-        if pdpe.huge() {
-            // SAFETY: Modifying cache bits of mapped memory in Ring 0 is safe.
-            unsafe {
-                (*entry_ptr(pdp, pdp_idx)).set_pwt(true);
+        // Dispatch on the shared walk to decide which level (if any) holds
+        // the mapping for `addr`, then apply the PWT bit at exactly that
+        // level. Missing entries at any level are skipped one page at a
+        // time (matching this function's original per-call behavior);
+        // that is a smaller skip than `reclaim_user_range`'s jump-by-region
+        // logic, but WC ranges (framebuffer/MMIO) are typically small
+        // contiguous windows, so this was never a hot path worth widening
+        // here, and preserving it avoids an unrelated behavior change.
+        match walk_levels(addr) {
+            WalkResult::Pml4Missing
+            | WalkResult::PdpMissing { .. }
+            | WalkResult::PdMissing { .. } => {
+                addr += PAGE_SIZE_U64;
             }
-            invlpg(addr);
-            addr = (addr + 0x4000_0000) & !0x3FFF_FFFF; // Advance by 1GiB
-            continue;
-        }
-
-        let pd = table_at(pd_table_addr(addr));
-        let pd_idx = pd_index(addr);
-        let pde = table_entry(pd, pd_idx);
-        if !pde.present() {
-            addr += PAGE_SIZE_U64;
-            continue;
-        }
-        if pde.huge() {
-            unsafe {
-                (*entry_ptr(pd, pd_idx)).set_pwt(true);
+            WalkResult::PdpHuge { .. } => {
+                let pdp = table_at(pdp_table_addr(addr));
+                let pdp_idx = pdp_index(addr);
+                // SAFETY: Modifying cache bits of mapped memory in Ring 0 is safe.
+                unsafe {
+                    (*entry_ptr(pdp, pdp_idx)).set_pwt(true);
+                }
+                invlpg(addr);
+                addr = (addr + 0x4000_0000) & !0x3FFF_FFFF; // Advance by 1GiB
             }
-            invlpg(addr);
-            addr = (addr + 0x20_0000) & !0x1F_FFFF; // Advance by 2MiB
-            continue;
-        }
-
-        let pt = table_at(pt_table_addr(addr));
-        let pt_idx = pt_index(addr);
-        if table_entry(pt, pt_idx).present() {
-            unsafe {
-                (*entry_ptr(pt, pt_idx)).set_pwt(true);
+            WalkResult::PdHuge { .. } => {
+                let pd = table_at(pd_table_addr(addr));
+                let pd_idx = pd_index(addr);
+                // SAFETY: Modifying cache bits of mapped memory in Ring 0 is safe.
+                unsafe {
+                    (*entry_ptr(pd, pd_idx)).set_pwt(true);
+                }
+                invlpg(addr);
+                addr = (addr + 0x20_0000) & !0x1F_FFFF; // Advance by 2MiB
             }
-            invlpg(addr);
+            WalkResult::Resolved { pt, .. } => {
+                let pt_idx = pt_index(addr);
+                if table_entry(pt, pt_idx).present() {
+                    // SAFETY: Modifying cache bits of mapped memory in Ring 0 is safe.
+                    unsafe {
+                        (*entry_ptr(pt, pt_idx)).set_pwt(true);
+                    }
+                    invlpg(addr);
+                }
+                addr += PAGE_SIZE_U64;
+            }
         }
-        addr += PAGE_SIZE_U64;
     }
 }

--- a/main64/kernel/src/memory/vmm/page_table.rs
+++ b/main64/kernel/src/memory/vmm/page_table.rs
@@ -522,41 +522,125 @@ pub fn zero_virt_page(addr: u64) {
     }
 }
 
+/// Outcome of walking the 4-level (PML4 -> PDP -> PD -> PT) page-table
+/// hierarchy for one virtual address, resolved against the currently active
+/// CR3 through the recursive self-mapping.
+///
+/// Every VMM function that needs to resolve a virtual address down to its
+/// leaf PTE -- or determine which level blocks that resolution -- shares this
+/// single walk instead of hand-rolling the PML4/PDP/PD bail sequence. A
+/// future change to how huge-page-in-path detection works only has to happen
+/// here (see issue #58).
+///
+/// Each variant carries the entries already resolved on the way down, so
+/// callers that need permission bits from intermediate levels (e.g.
+/// [`is_user_page_writable`]) do not have to re-read them.
+#[derive(Clone, Copy)]
+pub enum WalkResult {
+    /// The PML4 entry for this address is not present.
+    Pml4Missing,
+
+    /// PML4 present; the PDP entry is not present.
+    PdpMissing { pml4e: PageTableEntry },
+
+    /// PML4 present; the PDP entry is present but marks a 1 GiB huge-page
+    /// leaf. There is no PD table below a huge PDP entry, so the walk cannot
+    /// descend further.
+    PdpHuge {
+        pml4e: PageTableEntry,
+        pdpe: PageTableEntry,
+    },
+
+    /// PML4 + PDP present (PDP non-huge); the PD entry is not present.
+    PdMissing {
+        pml4e: PageTableEntry,
+        pdpe: PageTableEntry,
+    },
+
+    /// PML4 + PDP present (PDP non-huge); the PD entry is present but marks a
+    /// 2 MiB huge-page leaf. There is no PT table below a huge PD entry, so
+    /// the walk cannot descend further.
+    PdHuge {
+        pml4e: PageTableEntry,
+        pdpe: PageTableEntry,
+        pde: PageTableEntry,
+    },
+
+    /// All three intermediate levels are present and none is a huge-page
+    /// leaf. `pt` is the leaf page table; callers read/write the final PTE
+    /// through `table_entry`/`entry_ptr` at `pt_index(virtual_address)`.
+    Resolved {
+        pml4e: PageTableEntry,
+        pdpe: PageTableEntry,
+        pde: PageTableEntry,
+        pt: *mut PageTable,
+    },
+}
+
+/// Walks PML4 -> PDP -> PD -> PT for `virtual_address` against the
+/// currently active CR3 (through the recursive self-mapping), bailing out
+/// with the appropriate [`WalkResult`] variant as soon as a level is missing
+/// or huge-mapped.
+///
+/// This is the single shared implementation of the 4-level page-table walk
+/// used throughout the VMM; see [`WalkResult`] for what each outcome means.
+#[inline]
+pub fn walk_levels(virtual_address: u64) -> WalkResult {
+    // Level 1: PML4. No huge-page bit is architecturally valid at this level
+    // (there is no 512 GiB page size on x86_64), so only presence matters.
+    let pml4 = table_at(PML4_TABLE_ADDR);
+    let pml4e = table_entry(pml4, pml4_index(virtual_address));
+    if !pml4e.present() {
+        return WalkResult::Pml4Missing;
+    }
+
+    // Level 2: PDP. A present-but-huge entry is a 1 GiB data leaf; there is
+    // no PD table underneath it, so the walk stops here.
+    let pdp = table_at(pdp_table_addr(virtual_address));
+    let pdpe = table_entry(pdp, pdp_index(virtual_address));
+    if !pdpe.present() {
+        return WalkResult::PdpMissing { pml4e };
+    }
+    if pdpe.huge() {
+        return WalkResult::PdpHuge { pml4e, pdpe };
+    }
+
+    // Level 3: PD. A present-but-huge entry is a 2 MiB data leaf; there is no
+    // PT table underneath it, so the walk stops here.
+    let pd = table_at(pd_table_addr(virtual_address));
+    let pde = table_entry(pd, pd_index(virtual_address));
+    if !pde.present() {
+        return WalkResult::PdMissing { pml4e, pdpe };
+    }
+    if pde.huge() {
+        return WalkResult::PdHuge { pml4e, pdpe, pde };
+    }
+
+    // Level 4: leaf PT. Its recursive-mapping address is always computable
+    // once PD is confirmed present and non-huge; the caller inspects or
+    // mutates the actual PTE at `pt_index(virtual_address)`.
+    let pt = table_at(pt_table_addr(virtual_address));
+    WalkResult::Resolved {
+        pml4e,
+        pdpe,
+        pde,
+        pt,
+    }
+}
+
 /// Returns the PT containing `virtual_address` if all intermediate levels exist.
 ///
 /// Returns `None` if any level is non-present or uses a huge page mapping.
 ///
 #[inline]
 pub fn pt_for_if_present(virtual_address: u64) -> Option<*mut PageTable> {
-    // Resolve PML4 level and reject missing/huge entries.
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4_idx = pml4_index(virtual_address);
-    let pml4e = table_entry(pml4, pml4_idx);
-
-    if !pml4e.present() || pml4e.huge() {
-        return None;
+    // Delegate the PML4/PDP/PD bail sequence to the shared walk; only the
+    // PML4 huge-page check must still be applied here, since `walk_levels`
+    // does not special-case it (see `WalkResult::Pml4Missing` doc comment).
+    match walk_levels(virtual_address) {
+        WalkResult::Resolved { pml4e, pt, .. } if !pml4e.huge() => Some(pt),
+        _ => None,
     }
-
-    // Resolve PDP level and reject missing/huge entries.
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdp_idx = pdp_index(virtual_address);
-    let pdpe = table_entry(pdp, pdp_idx);
-
-    if !pdpe.present() || pdpe.huge() {
-        return None;
-    }
-
-    // Resolve PD level and reject missing/huge entries.
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pd_idx = pd_index(virtual_address);
-    let pde = table_entry(pd, pd_idx);
-
-    if !pde.present() || pde.huge() {
-        return None;
-    }
-
-    // All intermediate levels are present => return leaf PT table.
-    Some(table_at(pt_table_addr(virtual_address)))
 }
 
 /// Returns whether a present leaf mapping exists for `virtual_address`.
@@ -576,37 +660,56 @@ pub fn is_leaf_present(virtual_address: u64) -> bool {
 #[inline]
 pub fn is_user_page_writable(virtual_address: u64) -> bool {
     // Note: single-core, IF-disabled
-    // Step 1: Walk the PML4 and reject absent or supervisor/read-only paths.
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4e = table_entry(pml4, pml4_index(virtual_address));
-    if !pml4e.present() || !pml4e.user() || !pml4e.writable() {
-        return false;
-    }
+    // The shared walk only resolves presence/huge structure; effective
+    // user+writable permission still has to be checked level-by-level here,
+    // because a present-but-supervisor or present-but-read-only intermediate
+    // entry must reject the mapping even though the walk itself succeeds.
+    match walk_levels(virtual_address) {
+        // PML4 missing, or the walk bailed out below a level whose presence
+        // alone (with no permission bits available yet to check) already
+        // makes the address unwritable by user code.
+        WalkResult::Pml4Missing | WalkResult::PdpMissing { .. } | WalkResult::PdMissing { .. } => {
+            false
+        }
 
-    // Step 2: Apply the same effective-permission check at the PDPT level.
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdpe = table_entry(pdp, pdp_index(virtual_address));
-    if !pdpe.present() || !pdpe.user() || !pdpe.writable() {
-        return false;
-    }
-    if pdpe.huge() {
-        return true;
-    }
+        // Bailed at a 1 GiB huge PDP leaf: writable only if PML4 and PDP are
+        // both user + writable (no PD/PT to check underneath a huge page).
+        WalkResult::PdpHuge { pml4e, pdpe } => {
+            pml4e.user() && pml4e.writable() && pdpe.user() && pdpe.writable()
+        }
 
-    // Step 3: Check the page-directory level before descending to a 4 KiB PT.
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pde = table_entry(pd, pd_index(virtual_address));
-    if !pde.present() || !pde.user() || !pde.writable() {
-        return false;
-    }
-    if pde.huge() {
-        return true;
-    }
+        // Bailed at a 2 MiB huge PD leaf: writable only if PML4, PDP and PD
+        // are all user + writable.
+        WalkResult::PdHuge { pml4e, pdpe, pde } => {
+            pml4e.user()
+                && pml4e.writable()
+                && pdpe.user()
+                && pdpe.writable()
+                && pde.user()
+                && pde.writable()
+        }
 
-    // Step 4: Validate the final 4 KiB leaf entry.
-    let pt = table_at(pt_table_addr(virtual_address));
-    let pte = table_entry(pt, pt_index(virtual_address));
-    pte.present() && pte.user() && pte.writable()
+        // Full 4 KiB path resolved: every intermediate level must be user +
+        // writable, and the leaf PTE itself must be present, user, writable.
+        WalkResult::Resolved {
+            pml4e,
+            pdpe,
+            pde,
+            pt,
+        } => {
+            if !pml4e.user() || !pml4e.writable() {
+                return false;
+            }
+            if !pdpe.user() || !pdpe.writable() {
+                return false;
+            }
+            if !pde.user() || !pde.writable() {
+                return false;
+            }
+            let pte = table_entry(pt, pt_index(virtual_address));
+            pte.present() && pte.user() && pte.writable()
+        }
+    }
 }
 
 /// Returns whether one virtual page is present and effectively user-readable.
@@ -617,37 +720,42 @@ pub fn is_user_page_writable(virtual_address: u64) -> bool {
 #[inline]
 pub fn is_user_page_readable(virtual_address: u64) -> bool {
     // Note: single-core, IF-disabled
-    // Step 1: Walk the PML4 and reject absent or supervisor paths.
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4e = table_entry(pml4, pml4_index(virtual_address));
-    if !pml4e.present() || !pml4e.user() {
-        return false;
-    }
+    // Same structure as `is_user_page_writable`, but only the user bit (not
+    // writable) gates each level.
+    match walk_levels(virtual_address) {
+        WalkResult::Pml4Missing | WalkResult::PdpMissing { .. } | WalkResult::PdMissing { .. } => {
+            false
+        }
 
-    // Step 2: Apply the same effective-permission check at the PDPT level.
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdpe = table_entry(pdp, pdp_index(virtual_address));
-    if !pdpe.present() || !pdpe.user() {
-        return false;
-    }
-    if pdpe.huge() {
-        return true;
-    }
+        // Bailed at a 1 GiB huge PDP leaf: readable only if PML4 and PDP are
+        // both user-accessible.
+        WalkResult::PdpHuge { pml4e, pdpe } => pml4e.user() && pdpe.user(),
 
-    // Step 3: Check the page-directory level before descending to a 4 KiB PT.
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pde = table_entry(pd, pd_index(virtual_address));
-    if !pde.present() || !pde.user() {
-        return false;
-    }
-    if pde.huge() {
-        return true;
-    }
+        // Bailed at a 2 MiB huge PD leaf: readable only if PML4, PDP and PD
+        // are all user-accessible.
+        WalkResult::PdHuge { pml4e, pdpe, pde } => pml4e.user() && pdpe.user() && pde.user(),
 
-    // Step 4: Validate the final 4 KiB leaf entry.
-    let pt = table_at(pt_table_addr(virtual_address));
-    let pte = table_entry(pt, pt_index(virtual_address));
-    pte.present() && pte.user()
+        // Full 4 KiB path resolved: every intermediate level must be
+        // user-accessible, and the leaf PTE itself must be present + user.
+        WalkResult::Resolved {
+            pml4e,
+            pdpe,
+            pde,
+            pt,
+        } => {
+            if !pml4e.user() {
+                return false;
+            }
+            if !pdpe.user() {
+                return false;
+            }
+            if !pde.user() {
+                return false;
+            }
+            let pte = table_entry(pt, pt_index(virtual_address));
+            pte.present() && pte.user()
+        }
+    }
 }
 
 /// Returns whether `virtual_address` is currently mapped at ANY page granularity —
@@ -665,34 +773,14 @@ pub fn is_user_page_readable(virtual_address: u64) -> bool {
 /// no lower table), so the recursive-mapping accesses below are always valid.
 #[inline]
 pub fn is_va_mapped(virtual_address: u64) -> bool {
-    let pml4 = table_at(PML4_TABLE_ADDR);
-    let pml4e = table_entry(pml4, pml4_index(virtual_address));
-    if !pml4e.present() {
-        return false;
+    match walk_levels(virtual_address) {
+        WalkResult::Pml4Missing | WalkResult::PdpMissing { .. } | WalkResult::PdMissing { .. } => {
+            false
+        }
+        // 1 GiB / 2 MiB huge page: mapped, and there is no PD/PT below it.
+        WalkResult::PdpHuge { .. } | WalkResult::PdHuge { .. } => true,
+        WalkResult::Resolved { pt, .. } => table_entry(pt, pt_index(virtual_address)).present(),
     }
-
-    let pdp = table_at(pdp_table_addr(virtual_address));
-    let pdpe = table_entry(pdp, pdp_index(virtual_address));
-    if !pdpe.present() {
-        return false;
-    }
-    // 1 GiB huge page: mapped, and there is no PD below it.
-    if pdpe.huge() {
-        return true;
-    }
-
-    let pd = table_at(pd_table_addr(virtual_address));
-    let pde = table_entry(pd, pd_index(virtual_address));
-    if !pde.present() {
-        return false;
-    }
-    // 2 MiB huge page: mapped, and there is no PT below it.
-    if pde.huge() {
-        return true;
-    }
-
-    let pt = table_at(pt_table_addr(virtual_address));
-    table_entry(pt, pt_index(virtual_address)).present()
 }
 
 /// Returns whether a page-table page contains no present entries.

--- a/main64/kernel/tests/vmm_test.rs
+++ b/main64/kernel/tests/vmm_test.rs
@@ -12,9 +12,9 @@
 use core::panic::PanicInfo;
 use kaos_kernel::arch::interrupts;
 use kaos_kernel::memory::vmm::page_table::{
-    build_kernel_pml4_from_firmware, pd_index, pdp_index, phys_to_pfn, pml4_index, pt_index,
-    PageTable, PDP_TABLE_BASE, PD_TABLE_BASE, PML4_TABLE_ADDR, PT_ENTRIES, PT_TABLE_BASE,
-    RECURSIVE_SLOT,
+    build_kernel_pml4_from_firmware, entry_ptr, pd_index, pd_table_addr, pdp_index, pdp_table_addr,
+    phys_to_pfn, pml4_index, pt_index, walk_levels, PageTable, WalkResult, ENTRY_HUGE,
+    PDP_TABLE_BASE, PD_TABLE_BASE, PML4_TABLE_ADDR, PT_ENTRIES, PT_TABLE_BASE, RECURSIVE_SLOT,
 };
 use kaos_kernel::memory::{heap, pmm, vmm};
 
@@ -1128,4 +1128,312 @@ fn test_recursive_window_constants() {
     assert_eq!(PDP_TABLE_BASE, 0xFFFF_FFFF_FFE0_0000);
     assert_eq!(PD_TABLE_BASE, 0xFFFF_FFFF_C000_0000);
     assert_eq!(PT_TABLE_BASE, 0xFFFF_FF80_0000_0000);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #58: shared `walk_levels` page-table walk.
+//
+// The tests below exercise `page_table::walk_levels` directly against the
+// live kernel CR3, covering every bail point (PML4 missing, PDP missing/huge,
+// PD missing/huge, fully resolved) that used to be hand-duplicated across
+// `pt_for_if_present`, `is_user_page_writable`, `is_user_page_readable`,
+// `is_va_mapped`, the `diagnostics` helpers, and `mapping.rs`.
+//
+// All scratch virtual addresses below live in PML4 slot 257
+// (`0xFFFF_8080_0000_0000`..`0xFFFF_8100_0000_0000`, see `TEMP_CLONE_PML4_VA`'s
+// doc comment), the slot this test suite already uses for one-off scratch
+// mappings, at PDP indices not touched by any other test in this file.
+// ---------------------------------------------------------------------------
+
+/// Contract: walk_levels reports Pml4Missing for a virtual address whose PML4
+/// slot has never been populated.
+/// Given: PML4 slot 292 (`0xFFFF_9200_0000_0000`) is not used by any boot path,
+///        test fixture, or other test in this file.
+/// When: walk_levels is called for an address in that slot.
+/// Then: it returns WalkResult::Pml4Missing.
+/// Failure Impact: the shared walk's top-level bail condition regressed; every
+///       caller relying on it (is_va_mapped, is_user_page_writable/readable,
+///       pt_for_if_present, the diagnostics helpers) would misbehave.
+#[test_case]
+fn test_walk_levels_reports_pml4_missing() {
+    const UNUSED_SLOT_VA: u64 = 0xFFFF_9200_0000_0000;
+    assert_eq!(pml4_index(UNUSED_SLOT_VA), 292, "sanity: expected slot 292");
+
+    assert!(
+        matches!(walk_levels(UNUSED_SLOT_VA), WalkResult::Pml4Missing),
+        "an address in a never-populated PML4 slot must report Pml4Missing"
+    );
+}
+
+/// Contract: walk_levels reports PdpMissing when PML4 is present but the PDP
+/// entry was never created.
+/// Given: an anchor page is mapped at PDP index 200 within slot 257 (forcing
+///        PML4[257] to be present), and PDP index 205 within the same slot is
+///        left untouched.
+/// When: walk_levels is called for the untouched PDP index.
+/// Then: it returns WalkResult::PdpMissing, carrying the resolved PML4 entry.
+/// Failure Impact: same as above, one level deeper.
+#[test_case]
+fn test_walk_levels_reports_pdp_missing() {
+    const ANCHOR_VA: u64 = 0xFFFF_8080_0000_0000 + (200u64 << 30);
+    const TARGET_VA: u64 = 0xFFFF_8080_0000_0000 + (205u64 << 30);
+    assert_eq!(
+        pml4_index(ANCHOR_VA),
+        257,
+        "sanity: anchor stays in slot 257"
+    );
+    assert_eq!(
+        pml4_index(TARGET_VA),
+        257,
+        "sanity: target stays in slot 257"
+    );
+
+    vmm::unmap_virtual_address(ANCHOR_VA);
+    let anchor_frame = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("anchor frame alloc failed"));
+    vmm::try_map_virtual_to_physical(ANCHOR_VA, anchor_frame.physical_address())
+        .expect("anchor mapping should succeed");
+
+    match walk_levels(TARGET_VA) {
+        WalkResult::PdpMissing { pml4e } => {
+            assert!(
+                pml4e.present(),
+                "PML4 entry must be present (anchor mapped)"
+            );
+        }
+        _ => panic!("expected WalkResult::PdpMissing for an untouched PDP index"),
+    }
+
+    vmm::unmap_virtual_address(ANCHOR_VA);
+}
+
+/// Contract: walk_levels reports PdMissing when PML4+PDP are present but the
+/// PD entry was never created.
+/// Given: an anchor page is mapped at PDP index 210 / PD index 5 (forcing that
+///        PDP entry to be present), and PD index 300 within the same PDP is
+///        left untouched.
+/// When: walk_levels is called for the untouched PD index.
+/// Then: it returns WalkResult::PdMissing, carrying the resolved PML4/PDP entries.
+#[test_case]
+fn test_walk_levels_reports_pd_missing() {
+    const PDP_BASE: u64 = 0xFFFF_8080_0000_0000 + (210u64 << 30);
+    const ANCHOR_VA: u64 = PDP_BASE + (5u64 << 21);
+    const TARGET_VA: u64 = PDP_BASE + (300u64 << 21);
+    assert_eq!(pdp_index(ANCHOR_VA), 210, "sanity: anchor PDP index");
+    assert_eq!(
+        pdp_index(TARGET_VA),
+        210,
+        "sanity: target shares the same PDP"
+    );
+    assert_ne!(
+        pd_index(ANCHOR_VA),
+        pd_index(TARGET_VA),
+        "sanity: distinct PDs"
+    );
+
+    vmm::unmap_virtual_address(ANCHOR_VA);
+    let anchor_frame = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("anchor frame alloc failed"));
+    vmm::try_map_virtual_to_physical(ANCHOR_VA, anchor_frame.physical_address())
+        .expect("anchor mapping should succeed");
+
+    match walk_levels(TARGET_VA) {
+        WalkResult::PdMissing { pml4e, pdpe } => {
+            assert!(
+                pml4e.present(),
+                "PML4 entry must be present (anchor mapped)"
+            );
+            assert!(pdpe.present(), "PDP entry must be present (anchor mapped)");
+            assert!(
+                !pdpe.huge(),
+                "anchor mapping is a 4 KiB page, PDP must not be huge"
+            );
+        }
+        _ => panic!("expected WalkResult::PdMissing for an untouched PD index"),
+    }
+
+    vmm::unmap_virtual_address(ANCHOR_VA);
+}
+
+/// Contract: walk_levels resolves a fully-populated path down to the correct
+/// leaf PT, matching the physical frame the caller just mapped.
+#[test_case]
+fn test_walk_levels_resolves_mapped_page() {
+    const TEST_VA: u64 = 0xFFFF_8080_0000_0000 + (220u64 << 30);
+
+    vmm::unmap_virtual_address(TEST_VA);
+    let frame = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame alloc failed"));
+    vmm::try_map_virtual_to_physical(TEST_VA, frame.physical_address())
+        .expect("mapping should succeed");
+
+    match walk_levels(TEST_VA) {
+        WalkResult::Resolved {
+            pml4e,
+            pdpe,
+            pde,
+            pt,
+        } => {
+            assert!(pml4e.present() && !pml4e.huge());
+            assert!(pdpe.present() && !pdpe.huge());
+            assert!(pde.present() && !pde.huge());
+            // SAFETY: `pt` is the leaf PT `walk_levels` just resolved for
+            // `TEST_VA`, reached through the recursive self-mapping; `entries`
+            // is a public field and `pt_index(TEST_VA) < PT_ENTRIES`.
+            let pte = unsafe { (*pt).entries[pt_index(TEST_VA)] };
+            assert!(pte.present(), "leaf PTE must be present");
+            assert_eq!(
+                pte.frame(),
+                frame.pfn,
+                "resolved leaf frame must match the mapped physical frame"
+            );
+        }
+        _ => panic!("expected WalkResult::Resolved for a freshly mapped page"),
+    }
+
+    vmm::unmap_virtual_address(TEST_VA);
+}
+
+/// Contract: walk_levels reports PdpHuge (and does not touch the PD/PT below)
+/// when the PDP entry is a present 1 GiB huge-page leaf.
+/// Given: a normal 4 KiB mapping is created first (so PML4/PDP/PD/PT all
+///        exist), then the PDP entry's huge bit is forced on directly through
+///        the recursive mapping -- the kernel itself never creates huge
+///        entries, so this uses raw bit manipulation solely to exercise the
+///        walk's bail path; the bit is cleared again before teardown so the
+///        hierarchy is left exactly as `unmap_virtual_address` expects it.
+/// When: walk_levels is called while the huge bit is set.
+/// Then: it returns WalkResult::PdpHuge without dereferencing a PD/PT address
+///       computed from the (now huge) PDP entry's frame field.
+#[test_case]
+fn test_walk_levels_reports_pdp_huge() {
+    const TEST_VA: u64 = 0xFFFF_8080_0000_0000 + (230u64 << 30);
+
+    vmm::unmap_virtual_address(TEST_VA);
+    let frame = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame alloc failed"));
+    vmm::try_map_virtual_to_physical(TEST_VA, frame.physical_address())
+        .expect("mapping should succeed");
+
+    // Confirm the path is a normal, fully-resolved 4 KiB mapping before poking it.
+    assert!(matches!(walk_levels(TEST_VA), WalkResult::Resolved { .. }));
+
+    let pdp = pdp_table_addr(TEST_VA) as *mut PageTable;
+    let idx = pdp_index(TEST_VA);
+    // SAFETY:
+    // - `pdp` is the live, currently-mapped PDP table for `TEST_VA` (just
+    //   confirmed present/non-huge above), reached through the recursive
+    //   self-mapping; `idx < PT_ENTRIES`.
+    // - `PageTableEntry` is `#[repr(transparent)]` over `u64`, so reinterpreting
+    //   the entry pointer as `*mut u64` to flip one bit is layout-compatible.
+    // - This is test-only instrumentation: the huge bit is cleared again below
+    //   before any other code path (including this test's own cleanup) touches
+    //   the entry, so no other test observes the temporarily-huge entry.
+    unsafe {
+        let raw = entry_ptr(pdp, idx) as *mut u64;
+        *raw |= ENTRY_HUGE;
+    }
+
+    match walk_levels(TEST_VA) {
+        WalkResult::PdpHuge { pml4e, pdpe } => {
+            assert!(pml4e.present());
+            assert!(pdpe.present() && pdpe.huge());
+        }
+        _ => panic!("expected WalkResult::PdpHuge while the PDP huge bit is set"),
+    }
+
+    // SAFETY: same justification as above; this restores the entry to its
+    // original (non-huge) state before the normal unmap path runs.
+    unsafe {
+        let raw = entry_ptr(pdp, idx) as *mut u64;
+        *raw &= !ENTRY_HUGE;
+    }
+    vmm::unmap_virtual_address(TEST_VA);
+}
+
+/// Contract: walk_levels reports PdHuge (and does not touch the PT below)
+/// when the PD entry is a present 2 MiB huge-page leaf.
+/// Given/When/Then: mirrors `test_walk_levels_reports_pdp_huge` one level down.
+#[test_case]
+fn test_walk_levels_reports_pd_huge() {
+    const TEST_VA: u64 = 0xFFFF_8080_0000_0000 + (240u64 << 30);
+
+    vmm::unmap_virtual_address(TEST_VA);
+    let frame = pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame alloc failed"));
+    vmm::try_map_virtual_to_physical(TEST_VA, frame.physical_address())
+        .expect("mapping should succeed");
+
+    assert!(matches!(walk_levels(TEST_VA), WalkResult::Resolved { .. }));
+
+    let pd = pd_table_addr(TEST_VA) as *mut PageTable;
+    let idx = pd_index(TEST_VA);
+    // SAFETY: same justification as `test_walk_levels_reports_pdp_huge`, one
+    // level down (PD instead of PDP).
+    unsafe {
+        let raw = entry_ptr(pd, idx) as *mut u64;
+        *raw |= ENTRY_HUGE;
+    }
+
+    match walk_levels(TEST_VA) {
+        WalkResult::PdHuge { pml4e, pdpe, pde } => {
+            assert!(pml4e.present());
+            assert!(pdpe.present() && !pdpe.huge());
+            assert!(pde.present() && pde.huge());
+        }
+        _ => panic!("expected WalkResult::PdHuge while the PD huge bit is set"),
+    }
+
+    // SAFETY: restores the entry before the normal unmap path runs.
+    unsafe {
+        let raw = entry_ptr(pd, idx) as *mut u64;
+        *raw &= !ENTRY_HUGE;
+    }
+    vmm::unmap_virtual_address(TEST_VA);
+}
+
+/// Contract: destroy_user_address_space's catch-all reclaim (`reclaim_user_range`,
+/// refactored in issue #58 to resolve each present page's path once instead of
+/// walking it twice) still finds and releases every present leaf mapping, even
+/// when they are sparse and separated by both a 2 MiB (PD) and a 1 GiB (PDP)
+/// unmapped gap that the skip-ahead logic must jump over correctly.
+/// Given: three out-of-window pages are mapped directly at increasing
+///        distances (0, +2 MiB, +1 GiB) from a base VA outside all three known
+///        user regions (so only the generic catch-all scan can find them).
+/// When: destroy_user_address_space tears down the address space.
+/// Then: all three leaf frames are released back to the PMM.
+/// Failure Impact: a regression in the skip-jump/resolve dispatch would leak
+///       physical frames on every process exit -- exactly finding L1 warns about.
+#[test_case]
+fn test_destroy_user_address_space_reclaims_sparse_out_of_window_mappings() {
+    const BASE_VA: u64 = vmm::USER_HEAP_END + 0x0010_0000;
+    const FAR_VA_SAME_PDP: u64 = BASE_VA + 0x0020_0000; // +2 MiB: crosses a PD boundary
+    const FAR_VA_NEXT_PDP: u64 = BASE_VA + 0x4000_0000; // +1 GiB: crosses a PDP boundary
+    for va in [BASE_VA, FAR_VA_SAME_PDP, FAR_VA_NEXT_PDP] {
+        assert!(
+            vmm::classify_user_region(va).is_none(),
+            "test VA must not fall inside any of the three known user regions"
+        );
+    }
+
+    let user_cr3 = vmm::clone_kernel_pml4_for_user();
+    let frames: [_; 3] = [
+        pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame 0 allocation failed")),
+        pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame 1 allocation failed")),
+        pmm::with_pmm(|mgr| mgr.alloc_frame().expect("frame 2 allocation failed")),
+    ];
+    let vas = [BASE_VA, FAR_VA_SAME_PDP, FAR_VA_NEXT_PDP];
+
+    vmm::with_address_space(user_cr3, || {
+        for (va, frame) in vas.iter().zip(frames.iter()) {
+            vmm::try_map_virtual_to_physical(*va, frame.physical_address())
+                .expect("mapping an out-of-window VA should still succeed at the page-table level");
+        }
+    });
+
+    vmm::destroy_user_address_space(user_cr3);
+
+    for frame in &frames {
+        pmm::with_pmm(|mgr| {
+            assert!(
+                !mgr.release_pfn(frame.pfn),
+                "teardown's catch-all pass must have already reclaimed every sparse mapping"
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary

- Extracts a single shared `page_table::walk_levels(va) -> WalkResult` that performs the PML4 -> PDP -> PD -> PT walk with present/huge-page bail logic, replacing ~9 hand-duplicated copies across `page_table.rs`, `diagnostics.rs`, and `mapping.rs` (finding L2).
- Fixes `reclaim_user_range` walking the hierarchy twice per present page: it now feeds its already-resolved path directly into a shared `clear_leaf_and_prune` helper instead of re-entering `unmap_page_and_prune_pagetable_hierarchy`'s own full walk (finding L1).
- Adds 7 new integration tests exercising every `WalkResult` variant (`Pml4Missing`, `PdpMissing`, `PdMissing`, `PdpHuge`, `PdHuge`, `Resolved`) directly against the live kernel CR3, plus a regression test for `destroy_user_address_space` reclaiming sparse mappings across PD/PDP skip-jump boundaries.

Fixes #58

## Test plan

- [x] `cargo test` — 374/374 test cases pass across all 34 integration test binaries (including 7 new tests)
- [x] `cargo clippy` — clean, zero warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)