### PR TITLE
Syscall & test-framework hygiene: SAFETY comment, SeekFile truncation, dead match arm, substring gap (#59)

### DIFF
--- a/main64/kernel/src/syscall/dispatch/fs.rs
+++ b/main64/kernel/src/syscall/dispatch/fs.rs
@@ -19,6 +19,16 @@ pub fn read_user_string(
             return Err(SyscallError::InvalidArg);
         }
 
+        // SAFETY:
+        // - `len` starts at 0 and only ever grows past this point after the
+        //   previous iteration's `ptr.add(len)` was validated by
+        //   `is_valid_user_buffer_readable` and successfully dereferenced.
+        // - The loop guard above (`len >= max_len`) bounds `len` to
+        //   `max_len - 1` at this point, so `ptr.add(len)` cannot walk past
+        //   the caller-supplied maximum length.
+        // - This computes a pointer value only (no dereference); the result
+        //   is validated for user-accessibility immediately below before it
+        //   is ever read.
         if !is_valid_user_buffer_readable(unsafe { ptr.add(len) }, 1) {
             return Err(SyscallError::InvalidArg);
         }
@@ -100,6 +110,14 @@ pub fn syscall_delete_file_impl(name_ptr: *const u8) -> SyscallResult<u64> {
 
 /// Implements `SeekFile()`.
 pub fn syscall_seek_file_impl(fd: u64, offset: u64) -> SyscallResult<u64> {
+    // The VFS backend's `seek()` takes a `u32` offset. A silent `as u32`
+    // truncation here would let a caller pass e.g. `0x1_0000_0000` and have
+    // it quietly land on offset `0` instead - a wrong seek executed instead
+    // of a rejected one. Reject anything that would not round-trip instead.
+    if offset > u32::MAX as u64 {
+        return Err(SyscallError::InvalidArg);
+    }
+
     crate::io::vfs::seek(fd as usize, offset as u32).map_err(map_fs_error)?;
     Ok(0)
 }

--- a/main64/kernel/src/syscall/types.rs
+++ b/main64/kernel/src/syscall/types.rs
@@ -418,7 +418,6 @@ pub fn decode_result(raw: u64) -> Result<u64, SysError> {
         SYSCALL_ERR_IO => Err(SysError::IoError),
         SYSCALL_ERR_OUT_OF_MEMORY => Err(SysError::OutOfMemory),
         SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::PermissionDenied),
-        x if x >= SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::Unknown(x)),
         value => Ok(value),
     }
 }

--- a/main64/kernel/src/testing.rs
+++ b/main64/kernel/src/testing.rs
@@ -169,29 +169,67 @@ macro_rules! test_assert {
 /// This is used by panic contract tests to verify the expected panic behavior
 /// in a no_std environment.
 pub fn panic_message_contains(info: &core::panic::PanicInfo, expected: &str) -> bool {
-    struct Searcher<'a> {
-        search: &'a str,
-        found: bool,
+    // `core::fmt::Write::write_str` is called once per formatted fragment
+    // (e.g. once for each literal segment and once for each interpolated
+    // `{}`/`{:?}` argument), not once for the whole message. A search that
+    // checked each chunk independently would miss any `expected` substring
+    // that straddles a chunk boundary - e.g. static text immediately
+    // followed by an interpolated value - even though the fully assembled
+    // message does contain it. To avoid that gap, accumulate every chunk
+    // into one buffer here and search the assembled text exactly once,
+    // after formatting has finished.
+    //
+    // This deliberately uses a fixed-size stack buffer instead of
+    // `alloc::string::String`: panic contract tests may trigger this path
+    // before the kernel heap is initialized, and allocating from an
+    // uninitialized heap inside a panic-adjacent helper would itself abort -
+    // exactly the kind of hidden, environment-dependent failure this project
+    // avoids. 1 KiB is comfortably larger than any panic message produced by
+    // `test_assert!`/`test_assert_eq!` in this codebase; a message longer
+    // than that is truncated rather than dropped, which is an acceptable
+    // degradation for this test-only helper.
+    const CAPACITY: usize = 1024;
+
+    struct Accumulator {
+        buf: [u8; CAPACITY],
+        len: usize,
     }
 
-    impl<'a> core::fmt::Write for Searcher<'a> {
+    impl core::fmt::Write for Accumulator {
         fn write_str(&mut self, s: &str) -> core::fmt::Result {
-            // Check if the current chunk of the formatted panic message contains the substring
-            if s.contains(self.search) {
-                self.found = true;
-            }
+            // Copy as much of this fragment as still fits. Truncating here
+            // (rather than erroring out) means a message that overflows the
+            // buffer still yields a partial match instead of no match at all.
+            let bytes = s.as_bytes();
+            let remaining = CAPACITY - self.len;
+            let take = core::cmp::min(remaining, bytes.len());
+            self.buf[self.len..self.len + take].copy_from_slice(&bytes[..take]);
+            self.len += take;
             Ok(())
         }
     }
 
     use core::fmt::Write;
-    let mut searcher = Searcher {
-        search: expected,
-        found: false,
+    let mut accumulator = Accumulator {
+        buf: [0u8; CAPACITY],
+        len: 0,
     };
 
-    // Format the panic message into our searcher to scan for the expected substring
-    let _ = write!(&mut searcher, "{}", info.message());
+    // Format the panic message into our accumulator, then search the
+    // complete assembled text once so substrings spanning multiple
+    // `write_str` chunks are still found.
+    let _ = write!(&mut accumulator, "{}", info.message());
 
-    searcher.found
+    // Truncation above can only ever happen on a whole-fragment boundary
+    // (i.e. between `write_str` calls), but in the pathological case where a
+    // single fragment itself gets cut off mid-write, the tail bytes could
+    // split a multi-byte UTF-8 sequence. Fall back to the longest valid UTF-8
+    // prefix instead of unwrapping, so this helper never panics itself.
+    let filled = &accumulator.buf[..accumulator.len];
+    let text = match core::str::from_utf8(filled) {
+        Ok(text) => text,
+        Err(err) => core::str::from_utf8(&filled[..err.valid_up_to()]).unwrap_or(""),
+    };
+
+    text.contains(expected)
 }

--- a/main64/kernel/tests/syscall_dispatch_test.rs
+++ b/main64/kernel/tests/syscall_dispatch_test.rs
@@ -6,7 +6,12 @@
 #![test_runner(kaos_kernel::testing::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::panic::PanicInfo;
+use kaos_kernel::io::vfs::{self, FileMode, FileSystem, FsError};
 use kaos_kernel::syscall::{
     self, is_valid_user_buffer, is_valid_user_buffer_writable, SysError, SyscallId,
 };
@@ -1324,4 +1329,129 @@ fn test_read_path_rejects_unmapped_user_pages_in_loop() {
         end_frames,
         "PMM free frames must not change; demand mapping must not occur for invalid read-path buffers"
     );
+}
+
+/// Records the last offset the mounted test filesystem's `seek()` was called
+/// with, so tests below can prove which raw `u64` value actually reached the
+/// VFS backend after `syscall_seek_file_impl`'s validation.
+static SEEK_RECORDER_LAST_OFFSET: core::sync::atomic::AtomicU32 =
+    core::sync::atomic::AtomicU32::new(0);
+
+/// Minimal `FileSystem` test double whose `seek()` always succeeds and
+/// records the `u32` offset it was called with in `SEEK_RECORDER_LAST_OFFSET`.
+/// Used by the `SeekFile` tests below (L4, issue #59) to observe, from the
+/// outside, whether an out-of-range `u64` offset was rejected before
+/// reaching the backend, and whether an in-range offset arrives unchanged.
+struct SeekRecordingFs;
+
+impl FileSystem for SeekRecordingFs {
+    fn open(&self, _name: &str, _mode: FileMode) -> Result<usize, FsError> {
+        Ok(0)
+    }
+
+    fn close(&self, _fd: usize) -> Result<(), FsError> {
+        Ok(())
+    }
+
+    fn read(&self, _fd: usize, _buf: &mut [u8]) -> Result<usize, FsError> {
+        Ok(0)
+    }
+
+    fn write(&self, _fd: usize, _buf: &[u8]) -> Result<usize, FsError> {
+        Err(FsError::Unsupported)
+    }
+
+    fn seek(&self, _fd: usize, offset: u32) -> Result<(), FsError> {
+        SEEK_RECORDER_LAST_OFFSET.store(offset, core::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn eof(&self, _fd: usize) -> Result<bool, FsError> {
+        Ok(true)
+    }
+
+    fn delete(&self, _name: &str) -> Result<(), FsError> {
+        Err(FsError::Unsupported)
+    }
+
+    fn read_file(&self, _name: &str) -> Result<Vec<u8>, FsError> {
+        Ok(Vec::new())
+    }
+
+    fn print_root_directory(&self) {}
+
+    fn close_task_fds(&self, _task_id: usize) {}
+}
+
+/// Contract: `SeekFile` rejects a `u64` offset that does not fit in the VFS
+/// backend's `u32` offset type instead of silently truncating it.
+/// Given: A mounted test filesystem and a valid, open file descriptor.
+/// When: `SeekFile` is dispatched with an offset one greater than `u32::MAX`.
+/// Then: The syscall must return `SYSCALL_ERR_INVALID_ARG`, and the backend's
+/// `seek()` must never be reached (the recorder must not observe the
+/// truncated, wrapped-to-zero value that the pre-fix `as u32` cast would have
+/// silently produced and forwarded).
+#[test_case]
+fn test_seek_file_rejects_offset_above_u32_max() {
+    // Step 1: Mount a fresh test double and open a file descriptor.
+    vfs::reset_mounted_fs();
+    vfs::mount(Box::new(SeekRecordingFs));
+    let fd = vfs::open("whatever", FileMode::Read).expect("open must succeed on the test double");
+
+    // Step 2: Poison the recorder with a sentinel value that cannot arise
+    // from a legitimate in-range seek in this test.
+    SEEK_RECORDER_LAST_OFFSET.store(0xDEAD_BEEF, core::sync::atomic::Ordering::Relaxed);
+
+    // Step 3: Dispatch SeekFile with an offset one past `u32::MAX`.
+    let out_of_range_offset = u32::MAX as u64 + 1;
+    let ret = syscall::dispatch(
+        SyscallId::SeekFile as u64,
+        fd as u64,
+        out_of_range_offset,
+        0,
+        0,
+    );
+
+    assert!(
+        ret == syscall::SYSCALL_ERR_INVALID_ARG,
+        "offset above u32::MAX must be rejected with EINVAL instead of being truncated"
+    );
+    assert_eq!(
+        SEEK_RECORDER_LAST_OFFSET.load(core::sync::atomic::Ordering::Relaxed),
+        0xDEAD_BEEF,
+        "an out-of-range offset must be rejected before ever reaching the VFS backend"
+    );
+
+    vfs::reset_mounted_fs();
+}
+
+/// Contract: `SeekFile` still accepts an in-range `u64` offset and forwards
+/// it to the backend unchanged.
+/// Given: A mounted test filesystem and a valid, open file descriptor.
+/// When: `SeekFile` is dispatched with `u32::MAX` itself (the largest
+/// representable offset, and the boundary directly adjacent to the rejected
+/// case above).
+/// Then: The syscall must succeed, and the backend must observe exactly that
+/// offset.
+#[test_case]
+fn test_seek_file_accepts_offset_at_u32_max() {
+    // Step 1: Mount a fresh test double and open a file descriptor.
+    vfs::reset_mounted_fs();
+    vfs::mount(Box::new(SeekRecordingFs));
+    let fd = vfs::open("whatever", FileMode::Read).expect("open must succeed on the test double");
+
+    // Step 2: Dispatch SeekFile at the exact u32::MAX boundary.
+    let ret = syscall::dispatch(SyscallId::SeekFile as u64, fd as u64, u32::MAX as u64, 0, 0);
+
+    assert!(
+        ret == 0,
+        "an in-range offset at the u32::MAX boundary must still succeed"
+    );
+    assert_eq!(
+        SEEK_RECORDER_LAST_OFFSET.load(core::sync::atomic::Ordering::Relaxed),
+        u32::MAX,
+        "the in-range offset must reach the VFS backend unchanged"
+    );
+
+    vfs::reset_mounted_fs();
 }

--- a/main64/kernel/tests/test_framework_panic_message_test.rs
+++ b/main64/kernel/tests/test_framework_panic_message_test.rs
@@ -20,6 +20,13 @@
 //! formats via `Display`) to confirm the interpolated values survive.
 //! Under the pre-fix logic, an `as_str()`-based check on this same panic
 //! would have observed `None` and dropped the message entirely.
+//!
+//! This also covers L16 (issue #59): `panic_message_contains` used to check
+//! each formatter `write_str` chunk independently, so a search string
+//! spanning two chunks (e.g. static text immediately followed by an
+//! interpolated value) could be missed even though the fully assembled
+//! message contained it. The panic handler below additionally asserts on
+//! such a spanning substring.
 
 #![no_std]
 #![no_main]
@@ -47,19 +54,21 @@ fn panic(info: &PanicInfo) -> ! {
     // `test_panic_handler`) would see `None` for this panic, since it was
     // built with format arguments - making this contract unverifiable and
     // silently dropping the diagnostic in the real failure path.
-    //
-    // `panic_message_contains` scans one formatter `write_str` chunk at a
-    // time (see its doc comment in `testing.rs`) and does not stitch
-    // adjacent chunks together, so a search string that straddles a chunk
-    // boundary - e.g. static text immediately followed by a `{:?}`-formatted
-    // argument - can miss even though the full message contains it. To keep
-    // this test independent of that separately-tracked limitation, we search
-    // only for each interpolated numeric literal on its own, which is
-    // rendered as a single `write_str` chunk by the integer `Debug` impl.
     let has_left = kaos_kernel::testing::panic_message_contains(info, "246813579");
     let has_right = kaos_kernel::testing::panic_message_contains(info, "987654321");
 
-    if has_left && has_right {
+    // `panic_message_contains` now accumulates every formatter `write_str`
+    // chunk into one buffer before searching (see its doc comment in
+    // `testing.rs`), instead of checking each chunk in isolation. Prove that
+    // by searching for a substring that itself straddles a chunk boundary:
+    // `test_assert_eq!`'s format string emits the literal `"  left: \`"` as
+    // one `write_str` call and the interpolated `246813579` value (via the
+    // integer `Debug` impl) as a separate one, so this needle only exists in
+    // the fully assembled message, never inside a single chunk.
+    let has_spanning_substring =
+        kaos_kernel::testing::panic_message_contains(info, "left: `246813579`");
+
+    if has_left && has_right && has_spanning_substring {
         exit_qemu(QemuExitCode::Success);
     } else {
         exit_qemu(QemuExitCode::Failed);


### PR DESCRIPTION
## Summary

Four independent LOW-severity hygiene findings from issue #59, each a self-contained fix:

- **L3** — `kernel/src/syscall/dispatch/fs.rs`: added a missing `SAFETY:` comment on the `unsafe { ptr.add(len) }` pointer arithmetic in `read_user_string`. The computation was already sound (no overflow, since `len` is bounded by `max_len` and only advances after the previous address was validated), it was just undocumented per the project's mandatory `SAFETY:` comment policy.
- **L4** — `kernel/src/syscall/dispatch/fs.rs`: `syscall_seek_file_impl` (`SeekFile`) now rejects a `u64` offset greater than `u32::MAX` with `SyscallError::InvalidArg` instead of silently truncating it via `as u32` before forwarding to the VFS backend.
- **L5** — `kernel/src/syscall/types.rs`: removed the dead `x if x >= SYSCALL_ERR_PERMISSION_DENIED => Err(SysError::Unknown(x))` arm in `decode_result`. `SYSCALL_ERR_PERMISSION_DENIED` is the numerically smallest sentinel in the reserved error range, and every value from it up to `u64::MAX` is already matched exactly by the preceding arms, so this guard could never fire. Confirmed no test relied on it (the sentinel range has no gap values for it to catch).
- **L16** — `kernel/src/testing.rs`: `panic_message_contains` now accumulates every `core::fmt::Write::write_str` chunk into one buffer and searches the fully assembled text once, instead of checking each chunk independently. Previously a search string spanning two chunks (e.g. static text immediately followed by an interpolated `{:?}` value) could be missed even though the full message contained it. Uses a fixed-size stack buffer (not `alloc::String`) since this helper can run before the kernel heap is initialized — an earlier heap-based version of this fix caused `test_framework_panic_message_test` to hang in QEMU for exactly that reason.

## Tests

- `syscall_dispatch_test.rs`: two new tests using a `SeekRecordingFs` test double — `test_seek_file_rejects_offset_above_u32_max` (offset `u32::MAX + 1` is rejected before ever reaching the VFS backend) and `test_seek_file_accepts_offset_at_u32_max` (the boundary value `u32::MAX` still succeeds and reaches the backend unchanged).
- `test_framework_panic_message_test.rs`: extended to additionally assert on `"left: \`246813579\`"`, a substring that spans the literal-text chunk and the interpolated-value chunk of `test_assert_eq!`'s panic message — proving the L16 fix.
- No dead-code-arm-dependent tests existed for L5, so nothing needed to be removed there.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --lib --bins -- -D warnings` and `cargo clippy --test syscall_dispatch_test --test test_framework_panic_message_test -- -D warnings` — clean (zero warnings).
- `cargo test` (full suite, QEMU-backed) — **all 369 test cases across 34 test binaries pass**, including the new tests above.
- Note: `cargo clippy --tests` on the *unmodified* `vmm_test.rs` reports one pre-existing `clippy::bool_assert_comparison` warning unrelated to this change (verified present on `main` before this branch); left untouched as out of scope for issue #59.

Fixes #59