### PR TITLE
Fix #50: clamp AhciBlockDevice to AHCI's 48-bit LBA limit

### DIFF
--- a/main64/kernel/src/drivers/block.rs
+++ b/main64/kernel/src/drivers/block.rs
@@ -15,6 +15,13 @@ const MAX_SECTORS_PER_CMD: u32 = 255;
 /// Highest LBA addressable by 28-bit ATA PIO.
 const ATA_MAX_LBA: u64 = 0x0FFF_FFFF;
 
+/// Highest LBA addressable by AHCI's 48-bit LBA FIS fields (`lba0..lba5`,
+/// see `ahci::FisRegH2D`/`do_transfer`). Without this clamp `chunked()` would
+/// accept any `u64` LBA, letting an out-of-range value (e.g. a corrupted GPT
+/// `StartingLBA`, which is read as a raw unclamped `u64`) silently truncate
+/// to 48 bits inside the FIS instead of being rejected up front.
+const AHCI_MAX_LBA: u64 = 0xFFFF_FFFF_FFFF;
+
 /// Error variants for block device operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockError {
@@ -92,8 +99,9 @@ impl BlockDevice for AhciBlockDevice {
         // Step 1: Validate buffer size before requesting I/O.
         check_buf(buf.len(), count)?;
 
-        // Step 2: Chunk the request and forward to the AHCI driver.
-        chunked(lba, count, u64::MAX, |chunk_lba, chunk_cnt, off| {
+        // Step 2: Chunk the request and forward to the AHCI driver, clamping to
+        // the 48-bit LBA the FIS can actually encode.
+        chunked(lba, count, AHCI_MAX_LBA, |chunk_lba, chunk_cnt, off| {
             let bytes = chunk_cnt as usize * SECTOR_SIZE;
             ahci::read_sectors(&mut buf[off..off + bytes], chunk_lba, chunk_cnt)
                 .map_err(|_| BlockError::Device)
@@ -104,8 +112,9 @@ impl BlockDevice for AhciBlockDevice {
         // Step 1: Validate buffer size before requesting I/O.
         check_buf(buf.len(), count)?;
 
-        // Step 2: Chunk the request and forward to the AHCI driver.
-        chunked(lba, count, u64::MAX, |chunk_lba, chunk_cnt, off| {
+        // Step 2: Chunk the request and forward to the AHCI driver, clamping to
+        // the 48-bit LBA the FIS can actually encode.
+        chunked(lba, count, AHCI_MAX_LBA, |chunk_lba, chunk_cnt, off| {
             let bytes = chunk_cnt as usize * SECTOR_SIZE;
             ahci::write_sectors(&buf[off..off + bytes], chunk_lba, chunk_cnt)
                 .map_err(|_| BlockError::Device)

--- a/main64/kernel/tests/block_test.rs
+++ b/main64/kernel/tests/block_test.rs
@@ -95,6 +95,36 @@ fn test_block_lba_bounds_checking() {
     );
 }
 
+/// Contract: AHCI block device LBA validation logic (issue #50).
+/// Given: AHCI block device is selected as active.
+/// When: read_sectors is called with an LBA beyond AHCI's 48-bit FIS limit
+///   (0xFFFF_FFFF_FFFF), e.g. as could result from an unclamped, corrupted
+///   GPT `StartingLBA` read as a raw `u64`.
+/// Then: The function must return BlockError::OutOfRange *before* any
+///   hardware/driver call is attempted (chunked()'s range check runs first),
+///   rather than silently truncating the LBA to 48 bits inside the FIS.
+#[test_case]
+fn test_ahci_block_lba_bounds_checking() {
+    // Step 1: Initialize AHCI device registration in block facade.
+    block::init_ahci();
+
+    // Step 2: Attempt to read one sector at the first LBA that overflows
+    // AHCI's 48-bit addressable range.
+    let mut buf = [0u8; 512];
+    let result = block::read_sectors(0x1_0000_0000_0000, 1, &mut buf);
+    assert!(
+        matches!(result, Err(BlockError::OutOfRange)),
+        "read_sectors must reject LBA exceeding AHCI's 48-bit FIS limit"
+    );
+
+    // Step 3: Same contract must hold for writes.
+    let write_result = block::write_sectors(0x1_0000_0000_0000, 1, &buf);
+    assert!(
+        matches!(write_result, Err(BlockError::OutOfRange)),
+        "write_sectors must reject LBA exceeding AHCI's 48-bit FIS limit"
+    );
+}
+
 /// Contract: AHCI block device write policy.
 /// Given: AHCI block device is selected as active but hardware is not initialized.
 /// When: write_sectors is invoked.


### PR DESCRIPTION
## Summary

- `AhciBlockDevice::read_sectors`/`write_sectors` passed `u64::MAX` as the max addressable LBA to `chunked()`, so its range check never rejected an LBA beyond what AHCI's H2D FIS can actually encode (`lba0..lba5` = 48 bits, confirmed in `ahci.rs`'s FIS field writes around the `do_transfer` LBA encoding).
- A corrupted or crafted GPT partition entry's `StartingLBA` (read as a raw, unclamped `u64` in `gpt.rs`) exceeding 2^48 would silently truncate inside the FIS instead of being rejected — every subsequent read/write built from it would address the wrong, wrapped physical sector.
- Adds `AHCI_MAX_LBA = 0xFFFF_FFFF_FFFF` next to the existing `ATA_MAX_LBA = 0x0FFF_FFFF` clamp in `block.rs`, and passes it to `chunked()` in both the read and write paths of `AhciBlockDevice` (previously `block.rs:96,108`).
- No changes to `ahci.rs` or `gpt.rs` — the fix lives entirely in `block.rs`, matching the existing `AtaBlockDevice` pattern.

## Test plan

- Added `test_ahci_block_lba_bounds_checking` to `kernel/tests/block_test.rs`, mirroring the existing `test_block_lba_bounds_checking` (ATA) test: selects `AhciBlockDevice` as active and asserts both `read_sectors` and `write_sectors` return `BlockError::OutOfRange` for an LBA one past the 48-bit limit (`0x1_0000_0000_0000`), before any driver/hardware call is attempted.
- `cargo test` (kernel, run via QEMU test runner): all 453 test cases across 45 test files pass, including the new test.
- `cargo clippy --tests -- -D warnings` and `cargo clippy -- -D warnings`: zero warnings/errors.
- `cargo fmt --check`: zero diffs.

Closes #50