### PR TITLE
M9: Fix mark_range_used non-idempotency against overlapping ranges (#52)

### DIFF
--- a/main64/kernel/src/memory/pmm/manager.rs
+++ b/main64/kernel/src/memory/pmm/manager.rs
@@ -318,8 +318,16 @@ impl PhysicalMemoryManager {
     }
 
     /// Marks every page frame in the physical range `[range_start, range_end)`
-    /// as used by directly setting the corresponding bitmap bits.
+    /// as used by directly setting the corresponding bitmap bits, idempotently.
     /// This does not depend on the allocation order of `alloc_frame()`.
+    ///
+    /// Like [`mark_frame_used`](Self::mark_frame_used), each bit is inspected
+    /// before it is flipped: a frame that is already marked used (e.g. because
+    /// it falls inside a previously reserved range that overlaps this one) is
+    /// left untouched and `frames_free` is not decremented again for it. This
+    /// makes the function safe to call with ranges that overlap each other, or
+    /// a second time over the same range, without double-decrementing
+    /// `frames_free` and eventually underflowing it.
     fn mark_range_used(&mut self, range_start: u64, range_end: u64) {
         let regions = self.regions();
 
@@ -342,6 +350,20 @@ impl PhysicalMemoryManager {
             let bitmap = r.bitmap_start as *mut u64;
 
             for bit in first_bit..end_bit {
+                let word_idx = (bit / 64) as usize;
+                let bit_mask = 1u64 << (bit % 64);
+
+                // SAFETY:
+                // - `bit` is within the region bitmap bounds derived from overlap.
+                // - `bitmap` points to readable/writable PMM bitmap memory.
+                let word_val = unsafe { *bitmap.add(word_idx) };
+                if (word_val & bit_mask) != 0 {
+                    // Already marked used by an earlier (possibly overlapping)
+                    // call: skip it so `frames_free` is not decremented twice
+                    // for the same frame.
+                    continue;
+                }
+
                 // SAFETY:
                 // - `bit` is within the region bitmap bounds derived from overlap.
                 // - `bitmap` points to writable PMM bitmap memory.
@@ -349,6 +371,21 @@ impl PhysicalMemoryManager {
                 r.frames_free = r.frames_free.checked_sub(1).unwrap();
             }
         }
+    }
+
+    /// Test-only accessor for [`mark_range_used`](Self::mark_range_used).
+    ///
+    /// Hidden from public docs; lets integration tests under `tests/*.rs` exercise the
+    /// idempotency of this otherwise-private range-reservation path directly. Not gated
+    /// behind `#[cfg(test)]`: this crate builds with `[lib] test = false`, and integration
+    /// tests link `kaos_kernel` as an ordinary (non-`--cfg test`) dependency, so
+    /// `#[cfg(test)]` items in `src/` are never visible to them. Gated behind
+    /// `#[cfg(debug_assertions)]` instead — all test binaries build in the debug profile —
+    /// matching the existing `pic::EOI_COUNT`/`eoi_count_for_test` convention.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn mark_range_used_for_test(&mut self, range_start: u64, range_end: u64) {
+        self.mark_range_used(range_start, range_end);
     }
 
     /// Marks the single page frame containing `phys_addr` as used, idempotently.

--- a/main64/kernel/tests/pmm_test.rs
+++ b/main64/kernel/tests/pmm_test.rs
@@ -425,6 +425,88 @@ fn test_pmm_inc_refcount_rejects_unallocated_or_out_of_range_pfn() {
     });
 }
 
+/// Test that `mark_range_used` (exercised via the debug-only
+/// `mark_range_used_for_test` accessor) is idempotent against overlapping and
+/// repeated ranges — issue #52. Before the fix, every frame covered by more
+/// than one reserved range had `frames_free` decremented once per covering
+/// call, silently corrupting the free-frame count and, given enough overlap,
+/// eventually underflowing it (`checked_sub().unwrap()` panic).
+///
+/// The range used here is chosen deep inside the first managed region (far
+/// past `KERNEL_OFFSET`/`STACK_TOP` and any low-PFN churn from earlier tests
+/// in this binary), so it is guaranteed to start out free regardless of test
+/// execution order.
+/// Contract: pmm mark_range_used is idempotent against overlapping ranges.
+/// Given: A range of frames known to start out free.
+/// When: The range is marked used, then an overlapping range is marked used,
+///       then the original range is marked used again.
+/// Then: `frames_free` drops by exactly the number of *distinct* frames ever
+///       covered — never more, regardless of how many times a frame is
+///       re-covered by a later call.
+/// Failure Impact: Silent free-frame accounting corruption and an eventual
+///        `checked_sub().unwrap()` panic if a future change (or a bootloader
+///        supplying an overlapping metadata range) causes `mark_range_used`
+///        to be called with overlapping ranges. Release-blocking per #52.
+#[test_case]
+fn test_mark_range_used_is_idempotent_for_overlapping_ranges() {
+    pmm::with_pmm(|mgr| {
+        let region_start = mgr
+            .regions_snapshot()
+            .first()
+            .expect("PMM must have at least one region")
+            .start;
+
+        // Frame offsets A, B, C, D deep inside the region; A..C is the first
+        // reservation, C..E is a second reservation overlapping it at frame C.
+        let range_a_c_start = region_start + 5000 * pmm::PAGE_SIZE;
+        let range_a_c_end = range_a_c_start + 3 * pmm::PAGE_SIZE; // covers A, B, C
+        let range_c_e_start = range_a_c_start + 2 * pmm::PAGE_SIZE; // frame C
+        let range_c_e_end = range_c_e_start + 2 * pmm::PAGE_SIZE; // covers C, D
+
+        let free_before = mgr.total_free_frames();
+
+        // First call: marks 3 new frames (A, B, C) used.
+        mgr.mark_range_used_for_test(range_a_c_start, range_a_c_end);
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before - 3,
+            "first reservation must decrement frames_free by exactly the frames it covers"
+        );
+
+        // Second call overlaps at frame C: only D is a genuinely new frame,
+        // so frames_free must drop by 1, not 2.
+        mgr.mark_range_used_for_test(range_c_e_start, range_c_e_end);
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before - 4,
+            "an overlapping reservation must not double-decrement the shared frame"
+        );
+
+        // Repeating the very first range again must be a complete no-op: every
+        // frame it covers (A, B, C) is already marked used.
+        mgr.mark_range_used_for_test(range_a_c_start, range_a_c_end);
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before - 4,
+            "re-marking an already-reserved range must not change frames_free"
+        );
+
+        // Cleanup: these frames were never handed out via alloc_frame, so their
+        // refcount byte is still 0. release_pfn's documented refcount==0
+        // fallback treats a bitmap-set/refcount-0 frame as the "actually free"
+        // case, clearing the bit and restoring frames_free.
+        let start_pfn = range_a_c_start / pmm::PAGE_SIZE;
+        for pfn in start_pfn..start_pfn + 4 {
+            assert!(mgr.release_pfn(pfn), "cleanup release must succeed");
+        }
+        assert_eq!(
+            mgr.total_free_frames(),
+            free_before,
+            "cleanup must restore the original free-frame baseline"
+        );
+    });
+}
+
 // ============================================================================
 // #63 R1: `is_pfn_free` query + `assert_no_active_table_frame_is_pmm_free` guard.
 //


### PR DESCRIPTION
## Summary

- `mark_range_used` (`main64/kernel/src/memory/pmm/manager.rs`) unconditionally set each bitmap bit and decremented `frames_free` for every frame in the reserved range, unlike its sibling `mark_frame_used`, which checks the bit first. If `mark_range_used` is ever called with ranges that overlap (not reachable today — see the paths in `PhysicalMemoryManager::new()` — but a latent hazard called out in #52), every frame in the overlap would be double-decremented: silent free-frame accounting corruption immediately, and a hard panic (`checked_sub().unwrap()`) once enough double-decrements underflow `frames_free`.
- Fixed by mirroring `mark_frame_used`'s idempotency idiom inline in `mark_range_used`: each bit is inspected before being flipped, and a frame already marked used is skipped rather than re-decrementing `frames_free` for it. `mark_frame_used` itself is untouched.
- Added a debug-only `mark_range_used_for_test` accessor on `PhysicalMemoryManager`, following the existing `pic::eoi_count_for_test` convention (`#[cfg(test)]` items in `src/` are invisible to the `tests/*.rs` integration-test harness because `[lib] test = false`), so integration tests can exercise this otherwise-private function directly.
- Added `test_mark_range_used_is_idempotent_for_overlapping_ranges` to `kernel/tests/pmm_test.rs`: reserves a 3-frame range, reserves a second range overlapping it by one frame, then re-reserves the original range again, asserting `frames_free` only ever drops by the number of *distinct* frames actually covered (never double-decremented), then cleans up via `release_pfn`'s documented refcount==0 fallback.

## Test plan

- [x] `cargo test` (from `main64/kernel`) — all 453 test cases across 45 test files pass, including the new `pmm_test::test_mark_range_used_is_idempotent_for_overlapping_ranges`.
- [x] `cargo clippy -p kaos_kernel --target x86_64-unknown-none [--tests] -- -D warnings` — zero warnings/errors.
- [x] `cargo fmt --check` — zero diffs.

Closes #52