### PR TITLE
fix(#51): guard map_user_page's active-address-space precondition

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -77,6 +77,9 @@ name = "ata_panic_contract_test"
 name = "page_fault_death_test"
 
 [[test]]
+name = "map_user_page_interrupts_death_test"
+
+[[test]]
 name = "user_mode_iretq_smoke_test"
 
 [[test]]

--- a/main64/kernel/src/memory/vmm/mapping.rs
+++ b/main64/kernel/src/memory/vmm/mapping.rs
@@ -845,18 +845,19 @@ fn reclaim_user_range(scan_start: u64, scan_end: u64) {
 /// `virtual_address` must be within configured user code/stack regions and
 /// must not target the configured guard page.
 ///
-/// # Safety
 /// This function mutates page tables via recursive mapping and therefore
-/// requires a stable active address space while it runs.
-///
-/// Callers must execute it only inside `with_address_space` (or an equivalent
-/// critical section) that:
+/// requires a stable active address space while it runs. Callers must execute
+/// it only inside [`with_address_space`] (or an equivalent critical section)
+/// that:
 /// - disables interrupts for the full duration, and
 /// - guarantees `CR3` does not change until the function returns.
 ///
 /// If this precondition is violated, a context switch can switch to a different
 /// `CR3` while recursive addresses are being resolved, which can race and write
-/// into the wrong page-table hierarchy.
+/// into the wrong page-table hierarchy. This is not `unsafe fn` (no raw pointer
+/// or memory-layout invariant is handed to the caller to uphold), but the
+/// precondition is still checked in debug builds via a cheap `debug_assert!` in
+/// the shared [`map_user_leaf`] body — see issue #51.
 pub fn map_user_page(virtual_address: u64, pfn: u64, writable: bool) -> Result<(), MapError> {
     // Note: single-core, IF-disabled
     // Normalize to 4 KiB page granularity; callers may pass any address
@@ -900,10 +901,10 @@ pub fn map_user_page(virtual_address: u64, pfn: u64, writable: bool) -> Result<(
 /// ELF loader can give a R-X `.text` segment and a RW- `.data`/`.bss` segment
 /// different permissions within the same code window.
 ///
-/// # Safety
-/// Same contract as [`map_user_page`]: callers must run this only inside
+/// Same precondition as [`map_user_page`]: callers must run this only inside
 /// [`with_address_space`] (or an equivalent critical section) with interrupts
-/// disabled for the full duration and a stable `CR3`.
+/// disabled for the full duration and a stable `CR3` (checked via
+/// `debug_assert!` in the shared [`map_user_leaf`] body — see issue #51).
 pub fn map_user_code_page(
     virtual_address: u64,
     pfn: u64,
@@ -937,6 +938,22 @@ fn map_user_leaf(
     no_execute: bool,
 ) -> Result<(), MapError> {
     // Note: single-core, IF-disabled
+    //
+    // Debug-only precondition guard (issue #51): this function is deliberately a
+    // safe `fn`, not `unsafe fn`, because no raw pointer/layout invariant is
+    // handed to the caller — but it still relies on recursive-mapping addresses
+    // staying valid across every page-table write below, which only holds if
+    // the active address space cannot change mid-call. `with_address_space`
+    // (the only sanctioned entry point) always disables interrupts for its
+    // whole critical section, so "interrupts enabled here" is a cheap, reliable
+    // proxy for "precondition violated" without needing to track CR3 stability
+    // directly. This does nothing in release builds.
+    debug_assert!(
+        !interrupts::are_enabled(),
+        "map_user_leaf: must run with interrupts disabled (inside with_address_space); \
+         see map_user_page/map_user_code_page preconditions"
+    );
+
     // Ensure all intermediate levels exist and are marked user-accessible.
     populate_page_table_path(virtual_address, true)?;
     let pt = table_at(pt_table_addr(virtual_address));

--- a/main64/kernel/tests/map_user_page_interrupts_death_test.rs
+++ b/main64/kernel/tests/map_user_page_interrupts_death_test.rs
@@ -1,0 +1,78 @@
+//! Death test for issue #51: `map_user_page`'s "run only inside `with_address_space`"
+//! precondition must actually be checked, not just documented.
+//!
+//! `map_user_page`/`map_user_code_page` are safe `fn`s (not `unsafe fn`) that mutate
+//! page tables through the recursive-mapping window. That window only resolves
+//! correctly while `CR3` cannot change mid-call, which today is guaranteed solely by
+//! convention: every sanctioned caller wraps the call in `with_address_space`, which
+//! disables interrupts for its whole critical section. Nothing in the type system
+//! stopped a future caller from invoking `map_user_page` directly with interrupts
+//! still enabled.
+//!
+//! This test calls `vmm::map_user_page` directly, with interrupts deliberately left
+//! enabled (PIC lines stay masked by `interrupts::init()`, so no IRQ actually fires),
+//! and asserts that the `debug_assert!` added to the shared `map_user_leaf` body in
+//! `kernel/src/memory/vmm/mapping.rs` catches the violation and panics before any
+//! page-table write happens, rather than silently racing a future CR3 switch.
+//!
+//! See `kernel/src/memory/vmm/mapping.rs` (`map_user_leaf`).
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+
+use kaos_kernel::arch::interrupts;
+use kaos_kernel::arch::qemu::{exit_qemu, QemuExitCode};
+use kaos_kernel::memory::vmm::USER_CODE_BASE;
+use kaos_kernel::memory::{heap, pmm, vmm};
+
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+
+    // Mirror the standard VMM test boot sequence (see `vmm_test.rs`) so the
+    // recursive-mapping window is live before we probe the guard.
+    pmm::init(false);
+    interrupts::init();
+    vmm::init(false);
+    heap::init(false);
+
+    test_main();
+
+    // The test must panic (via the debug_assert) before reaching this point.
+    exit_qemu(QemuExitCode::Failed);
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    let expected = "map_user_leaf: must run with interrupts disabled";
+    if kaos_kernel::testing::panic_message_contains(info, expected) {
+        exit_qemu(QemuExitCode::Success);
+    } else {
+        exit_qemu(QemuExitCode::Failed);
+    }
+}
+
+/// Contract: calling `map_user_page` with interrupts enabled (i.e. outside
+/// `with_address_space`) trips the debug-only precondition guard instead of
+/// silently touching page tables under a CR3 that could change underneath it.
+/// Failure Impact: without this guard, a future caller who forgets to wrap the
+/// call in `with_address_space` gets no diagnostic — a preemption mid-call can
+/// write into the wrong page-table hierarchy, corrupting an unrelated address
+/// space. Release-blocking if the guard silently regresses.
+#[test_case]
+fn test_map_user_page_panics_when_interrupts_enabled() {
+    // Interrupt lines are masked by `interrupts::init()` above, so enabling IF
+    // here cannot actually deliver an IRQ mid-test; it only flips the flag the
+    // guard inspects.
+    interrupts::enable();
+
+    // Any user-code-window address/PFN works: the debug_assert fires before
+    // the function ever reads or writes a page-table entry.
+    let _ = vmm::map_user_page(USER_CODE_BASE, 0, true);
+}


### PR DESCRIPTION
## Summary

`map_user_page` (and its sibling `map_user_code_page`) documented an unsafe-grade precondition using rustdoc's `# Safety` convention:

> Callers must execute it only inside `with_address_space` ... that disables interrupts for the full duration and guarantees `CR3` does not change until the function returns. If violated ... can race and write into the wrong page-table hierarchy.

But neither function is `unsafe fn`, so nothing in the type system enforced this for a future caller — the `# Safety` heading is normally reserved for functions the compiler genuinely can't check.

## Approach chosen

I picked **option (b): keep the functions safe, add a cheap debug-only guard** rather than making them `unsafe fn` (option a, matching `switch_page_directory`'s pattern):

- Both existing call sites (`process/loader.rs:304`, `syscall/dispatch/process.rs:182`) already invoke the function from inside `with_address_space`, so `unsafe fn` would require updating both call sites' `SAFETY:` comments for no behavioral change — a larger, less surgical diff for the same net safety.
- `crate::arch::interrupts::are_enabled()` already exists in this codebase (used by `with_address_space` itself, plus `spinlock.rs`, `waitqueue_adapter.rs`, `ata.rs`), so the guard is a one-line, zero-new-API addition.
- `with_address_space` (the only sanctioned entry point) always disables interrupts for its whole critical section, so "interrupts enabled" is a reliable, cheap proxy for "precondition violated."

## What changed

- `main64/kernel/src/memory/vmm/mapping.rs`: added `debug_assert!(!interrupts::are_enabled(), ...)` to the shared `map_user_leaf` body — the single internal function both `map_user_page` and `map_user_code_page` funnel through, so one guard covers both public entry points. Reworded both functions' doc comments from the `# Safety` rustdoc heading to plain prose (matching how `with_address_space`/`destroy_user_address_space_with_page_counts` already document non-`unsafe` preconditions in this file), and noted the debug-only check.
- `main64/kernel/tests/map_user_page_interrupts_death_test.rs` (new): a QEMU-boot death test, following the existing `*_death_test.rs` pattern (e.g. `huge_mapping_align_death_test.rs`). It boots a minimal kernel, enables interrupts (PIC lines stay masked so no IRQ actually fires), then calls `vmm::map_user_page` directly — outside `with_address_space` — and asserts the panic message matches the guard.
- `main64/kernel/Cargo.toml`: registered the new `[[test]]` entry.

## Testing

- Manually verified the test is meaningful: temporarily disabled the `debug_assert!` and re-ran the new test — it ran to completion (`[ok]`) instead of panicking, confirming it would fail without the guard. Restored the guard afterward.
- `cargo test` (full suite): **453/453 test cases pass across 46 test files**, including the new death test.
- `cargo clippy` (lib + every test binary individually, `-D warnings`): zero warnings/errors. (`cargo clippy --all-targets` fails to build on `main` too — unrelated to this change — because the custom `no_std`/`harness=false` test setup can't compile as a `--all-targets` unit-test target; verified this pre-exists by stashing and re-running.)
- `cargo fmt --check`: clean, zero diff.

Closes #51