### PR TITLE
M10: add stopgap authorization for Exec and Wait syscalls

### DIFF
--- a/main64/kernel/src/scheduler/roundrobin/api.rs
+++ b/main64/kernel/src/scheduler/roundrobin/api.rs
@@ -219,6 +219,110 @@ pub fn set_current_user_heap_top(new_top: u64) -> bool {
     })
 }
 
+/// Attempts to record one more `Exec`-spawned child for `task_id`, enforcing
+/// a per-task cap.
+///
+/// Returns `true` and increments the task's `exec_count` when the task is a
+/// live slot whose current count is still below `max`. Returns `false`
+/// (without mutating state) when the slot is unused/unknown or the cap has
+/// already been reached.
+///
+/// Stopgap denial-of-service guard (M10, `docs/CODE_REVIEW_2026-07-26.md`):
+/// `syscall_exec_impl` calls this before spawning a child so an unprivileged
+/// ring-3 task cannot loop `Exec` to exhaust scheduler slots or PMM frames.
+///
+/// `task_id` is a packed task identifier (slot + generation) as returned by
+/// the spawn functions; the generation portion is ignored by this mutation.
+pub fn try_increment_exec_count(task_id: usize, max: u32) -> bool {
+    let slot = task_id_slot(task_id);
+    with_scheduler(|meta| {
+        if slot >= meta.slots.len() || !meta.slots[slot].used {
+            return false;
+        }
+
+        let entry = &mut meta.slots[slot];
+        if entry.exec_count >= max {
+            return false;
+        }
+
+        entry.exec_count += 1;
+        true
+    })
+}
+
+/// Maximum number of `(child, parent)` `Exec`-spawn relationships retained in
+/// [`SchedulerMetadata::parent_log`](super::types::SchedulerMetadata) for
+/// `is_parent_of` authorization checks.
+///
+/// Bounded so a sustained stream of `Exec` calls across many different tasks
+/// (each individually capped by `MAX_CHILD_EXECS` in
+/// `syscall::dispatch::process`) cannot grow scheduler memory without bound;
+/// the oldest record is evicted once the cap is reached.
+const PARENT_LOG_CAPACITY: usize = 256;
+
+/// Records `parent_task_id` as the spawning parent of `task_id`.
+///
+/// Returns `false` (without mutating state) if `task_id`'s slot is unused.
+///
+/// Stopgap authorization mechanism for `Wait` (M10,
+/// `docs/CODE_REVIEW_2026-07-26.md`): `syscall_exec_impl` calls this right
+/// after a successful spawn so `is_parent_of` can later scope which tasks the
+/// caller is authorized to `Wait` on. The record is appended to
+/// `SchedulerMetadata::parent_log` rather than stored on `TaskEntry`, so it
+/// remains queryable after the child exits and its slot is reaped (the
+/// common case: a parent typically calls `Wait` after, or racing, the
+/// child's exit).
+///
+/// `task_id` is a packed task identifier (slot + generation) as returned by
+/// the spawn functions; the generation portion is ignored by this mutation.
+/// `parent_task_id` is stored verbatim as the full packed identifier of the
+/// caller at spawn time.
+pub fn set_task_parent(task_id: usize, parent_task_id: usize) -> bool {
+    let slot = task_id_slot(task_id);
+    with_scheduler(|meta| {
+        if slot >= meta.slots.len() || !meta.slots[slot].used {
+            return false;
+        }
+
+        // Step 1: Evict the oldest record once the log is at capacity so it
+        // cannot grow without bound (M10). `remove(0)` is O(n), but n is
+        // capped at `PARENT_LOG_CAPACITY`, so this stays cheap.
+        if meta.parent_log.len() >= PARENT_LOG_CAPACITY {
+            meta.parent_log.remove(0);
+        }
+
+        // Step 2: Best-effort append. If the reservation fails, the spawn
+        // itself already succeeded; simply not recording lineage here just
+        // means `is_parent_of` later falls back to its safe default (deny),
+        // rather than this call failing the already-completed spawn.
+        if meta.parent_log.try_reserve(1).is_ok() {
+            meta.parent_log.push((task_id, parent_task_id));
+        }
+
+        true
+    })
+}
+
+/// Returns whether `parent_task_id` is a recorded `Exec`-spawning parent of
+/// `child_task_id`.
+///
+/// Both arguments are compared as full packed task identifiers (slot +
+/// generation), so a coincidental slot reuse cannot be mistaken for a live
+/// parent/child relationship (R-18): a reused slot's current generation no
+/// longer matches the stale `child_task_id` used to record the original
+/// relationship.
+///
+/// Looks up `SchedulerMetadata::parent_log` rather than live `TaskEntry`
+/// state, so this remains accurate even after `child_task_id` has already
+/// exited and been reaped -- see `set_task_parent`.
+pub fn is_parent_of(parent_task_id: usize, child_task_id: usize) -> bool {
+    with_scheduler(|meta| {
+        meta.parent_log
+            .iter()
+            .any(|&(child, parent)| child == child_task_id && parent == parent_task_id)
+    })
+}
+
 /// Resets the scheduler initialization state to `false`.
 ///
 /// This is a test-only helper to simulate initialization failure.

--- a/main64/kernel/src/scheduler/roundrobin/mod.rs
+++ b/main64/kernel/src/scheduler/roundrobin/mod.rs
@@ -46,9 +46,10 @@ mod wait;
 
 #[allow(unused_imports)]
 pub use api::{
-    current_task_id, current_user_heap_top, is_task_privileged, is_user_task,
-    reset_initialization_for_test, set_current_user_heap_top, set_task_user_context,
-    slot_table_len, task_context, task_frame_ptr, task_generation, task_iret_frame, task_state,
+    current_task_id, current_user_heap_top, is_parent_of, is_task_privileged, is_user_task,
+    reset_initialization_for_test, set_current_user_heap_top, set_task_parent,
+    set_task_user_context, slot_table_len, task_context, task_frame_ptr, task_generation,
+    task_iret_frame, task_state, try_increment_exec_count,
 };
 #[allow(unused_imports)]
 pub use spawn::{spawn_kernel_task, spawn_user_task, spawn_user_task_owning_code};

--- a/main64/kernel/src/scheduler/roundrobin/spawn.rs
+++ b/main64/kernel/src/scheduler/roundrobin/spawn.rs
@@ -182,6 +182,12 @@ fn spawn_internal(kind: SpawnKind) -> Result<usize, SpawnError> {
             kernel_rsp_top,
             is_user,
             privileged,
+            // The Exec child-rate-limit counter always starts at zero for a
+            // freshly (re)used slot (M10); parent/child lineage for `Wait`
+            // authorization is tracked separately in
+            // `SchedulerMetadata::parent_log`, not on `TaskEntry`, so it
+            // survives this task's eventual reap (see `set_task_parent`).
+            exec_count: 0,
             stack_base: stack_ptr,
             stack_size: TASK_STACK_SIZE,
             fpu_state: fpu_ptr,

--- a/main64/kernel/src/scheduler/roundrobin/types.rs
+++ b/main64/kernel/src/scheduler/roundrobin/types.rs
@@ -172,6 +172,16 @@ pub struct TaskEntry {
     /// tasks and defaults to `false` for everyone except the boot shell.
     pub privileged: bool,
 
+    /// Number of child tasks this task has spawned via the `Exec` syscall.
+    ///
+    /// Stopgap denial-of-service guard (M10, `docs/CODE_REVIEW_2026-07-26.md`):
+    /// bounds how many times a single task may successfully call `Exec`
+    /// before `syscall_exec_impl` starts rejecting further attempts with
+    /// `SyscallError::PermissionDenied`. Without this, an unprivileged
+    /// ring-3 task could loop `Exec` to exhaust scheduler slots or PMM
+    /// frames. See `try_increment_exec_count` in `scheduler::api`.
+    pub exec_count: u32,
+
     /// Base address of this task's heap-allocated kernel stack.
     pub stack_base: *mut u8,
 
@@ -204,6 +214,7 @@ impl TaskEntry {
             kernel_rsp_top: 0,
             is_user: false,
             privileged: false,
+            exec_count: 0,
             stack_base: ptr::null_mut(),
             stack_size: 0,
             fpu_state: ptr::null_mut(),
@@ -300,6 +311,22 @@ pub struct SchedulerMetadata {
     /// restores a task's state.  Cleared to `None` by `select_next_task`
     /// after saving the outgoing owner's state via `FXSAVE64`.
     pub fpu_owner: Option<usize>,
+
+    /// Ring log of recent `Exec`-spawn parent/child relationships, recorded
+    /// as full packed task identifiers `(child_task_id, parent_task_id)`.
+    ///
+    /// Stopgap authorization record for the `Wait` syscall (M10,
+    /// `docs/CODE_REVIEW_2026-07-26.md`): unlike a field on `TaskEntry`,
+    /// entries here intentionally **survive** `remove_task` reaping the
+    /// child's slot (which wholesale-resets the slot to `TaskEntry::empty()`
+    /// for reuse), so a parent remains authorized to `Wait` on a child that
+    /// has already exited — the common case, since `Wait` is typically
+    /// called after, or racing, the child's exit. Bounded to
+    /// `PARENT_LOG_CAPACITY` entries (see `scheduler::api`) with FIFO
+    /// eviction of the oldest record once full, so this cannot grow without
+    /// bound even under a sustained `Exec` loop (itself separately capped
+    /// per-task by `MAX_CHILD_EXECS` in `syscall::dispatch::process`).
+    pub parent_log: Vec<(usize, usize)>,
 }
 
 impl SchedulerMetadata {
@@ -320,6 +347,7 @@ impl SchedulerMetadata {
             pending_free_stacks: Vec::new(),
             pending_free_address_spaces: Vec::new(),
             fpu_owner: None,
+            parent_log: Vec::new(),
         }
     }
 }

--- a/main64/kernel/src/syscall/dispatch/bios.rs
+++ b/main64/kernel/src/syscall/dispatch/bios.rs
@@ -56,6 +56,18 @@ fn unified_memory_map() -> Option<&'static [crate::boot_info::UnifiedMemoryEntry
 /// unified map published by the loader; only falls back to the low BIOS Information
 /// Block when no `BootInfo` is present. See [`unified_memory_map`] for why the low
 /// read must not be unconditional.
+///
+/// # Authorization (M10, `docs/CODE_REVIEW_2026-07-26.md`)
+/// Like `GetPciDeviceCount`/`GetPciDevice` (`syscall/dispatch/pci.rs`), this
+/// syscall is deliberately **not** gated behind `TaskEntry::privileged`. The
+/// shipped `TUI.BIN` hardware-inspection screen (`user_programs/tui_app`) is
+/// an unprivileged `Exec`-spawned task and relies on this syscall to display
+/// the memory map; a privilege gate would break that shipped feature. This
+/// single-tenant kernel has no isolation boundary between ring-3 tasks that
+/// the E820/UEFI memory map would need to be kept secret across, so the
+/// M10 stopgap decision here is "no change" rather than a gate. See
+/// `syscall/dispatch/pci.rs`'s `GetPciDeviceCount` doc for the full
+/// rationale, which applies identically here.
 pub fn syscall_get_bios_memory_map_entry_count_impl() -> SyscallResult<u64> {
     if let Some(map) = unified_memory_map() {
         return Ok(map.len() as u64);

--- a/main64/kernel/src/syscall/dispatch/pci.rs
+++ b/main64/kernel/src/syscall/dispatch/pci.rs
@@ -8,6 +8,20 @@ use crate::syscall::types::{
 /// Implements `GetPciDeviceCount()`.
 ///
 /// Returns the total count of discovered PCI devices on the bus scan.
+///
+/// # Authorization (M10, `docs/CODE_REVIEW_2026-07-26.md`)
+/// This syscall is deliberately **not** gated behind `TaskEntry::privileged`,
+/// unlike `Shutdown`. Gating it would restrict PCI enumeration to the boot
+/// shell alone: every `Exec`-spawned task (including the shipped `TUI.BIN`
+/// hardware-inspection screen, `user_programs/tui_app`) is always
+/// unprivileged (see M6, `docs/CODE_REVIEW_2026-07-23.md`), so a privilege
+/// gate here would break that shipped feature rather than mitigate a real
+/// trust-boundary crossing. This kernel has no multi-user/multi-tenant
+/// isolation model — every ring-3 task already belongs to the same operator
+/// — so PCI topology/BAR data read here is not a secret relative to the
+/// existing threat model. The DoS/information-leak risk this syscall poses
+/// (M10) is judged low enough that the correct stopgap is "no change" rather
+/// than a gate that regresses shipped functionality.
 pub fn syscall_get_pci_device_count_impl() -> SyscallResult<u64> {
     // Step 1: Query the boot-time cached PCI device registry.
     let count = pci::get_devices().len();

--- a/main64/kernel/src/syscall/dispatch/process.rs
+++ b/main64/kernel/src/syscall/dispatch/process.rs
@@ -339,8 +339,10 @@ pub fn syscall_exec_impl(name_ptr: *const u8) -> SyscallResult<u64> {
 /// fingerprint which ids are currently alive (an existence side-channel),
 /// since a live target blocks the caller while an absent one returns
 /// immediately. To close this, a caller without the `privileged` capability
-/// may only `Wait` on a task it actually spawned via `Exec` (tracked by
-/// `TaskEntry::parent`, set in `syscall_exec_impl`); every other target is
+/// may only `Wait` on a task it actually spawned via `Exec` (tracked in
+/// `SchedulerMetadata::parent_log`, recorded via `set_task_parent` in
+/// `syscall_exec_impl` and queried through
+/// [`is_parent_of`](crate::scheduler::is_parent_of)); every other target is
 /// rejected with [`SyscallError::PermissionDenied`] *before* the target's
 /// existence is ever checked, so the response does not depend on whether
 /// `task_id` is alive, exited, or was never valid.

--- a/main64/kernel/src/syscall/dispatch/process.rs
+++ b/main64/kernel/src/syscall/dispatch/process.rs
@@ -239,25 +239,58 @@ pub fn syscall_mmap_impl(addr: u64, length: usize) -> SyscallResult<u64> {
     Ok(current_heap_top)
 }
 
+/// Maximum number of children a single task may spawn via `Exec` before
+/// further attempts are rejected with [`SyscallError::PermissionDenied`].
+///
+/// Stopgap denial-of-service guard (M10, `docs/CODE_REVIEW_2026-07-26.md`):
+/// without a cap, a malicious or buggy unprivileged ring-3 task can loop
+/// `Exec` to exhaust scheduler slots or PMM physical frames. The value is
+/// deliberately generous for legitimate usage (a shell/script launching a
+/// handful of programs per session) while still bounding a runaway loop to a
+/// small, recoverable number of tasks rather than "until the machine falls
+/// over".
+const MAX_CHILD_EXECS: u32 = 32;
+
 /// Implements `Exec(name_ptr)`: load and spawn a new user task from the filesystem.
 ///
 /// Reads the name string from user space safely and invokes the file loader.
 /// Each `ExecError` variant is mapped to the most appropriate `SyscallError`
 /// so user-space callers can distinguish file-not-found from spawn failures.
+///
+/// # Authorization (M10, `docs/CODE_REVIEW_2026-07-26.md`)
+/// Every calling task is rate-limited to [`MAX_CHILD_EXECS`] successful *and*
+/// unsuccessful `Exec` attempts via
+/// [`try_increment_exec_count`](crate::scheduler::try_increment_exec_count):
+/// once the cap is reached the syscall is denied outright, before user memory
+/// or the filesystem are ever touched. On a successful spawn, the new task's
+/// `parent` is recorded as the caller so `Wait` can later scope which task
+/// ids the caller is authorized to wait on (see `syscall_wait_impl`).
 pub fn syscall_exec_impl(name_ptr: *const u8) -> SyscallResult<u64> {
     use crate::process::ExecError;
 
     // Step 1: Clear global keyboard buffers so that any leftover shell keystrokes
     // or enter press from spawning do not bleed into the newly executed process.
+    // This happens unconditionally, even when the call is later rejected below,
+    // matching the pre-existing contract that `Exec` always clears stale input.
     keyboard::clear_buffers();
 
-    // Step 2: Decode the null-terminated string from user-space memory.
+    // Step 2: Identify the calling task and enforce the per-task Exec rate
+    // limit up front, before user memory or the filesystem are touched. A
+    // missing task context (e.g. called outside a scheduled task) has no
+    // counter to rate-limit, so treat it the same way `read_user_string`
+    // already treats a null pointer below.
+    let task_id = scheduler::current_task_id().ok_or(SyscallError::InvalidArg)?;
+    if !scheduler::try_increment_exec_count(task_id, MAX_CHILD_EXECS) {
+        return Err(SyscallError::PermissionDenied);
+    }
+
+    // Step 3: Decode the null-terminated string from user-space memory.
     let name = super::fs::read_user_string(name_ptr, 128)?;
 
-    // Step 3: Attempt to load the program image and spawn a user task.
+    // Step 4: Attempt to load the program image and spawn a user task.
     let result = crate::process::exec_from_vfs(&name);
 
-    // Step 4: Log the outcome to serial so failures are visible without a debugger.
+    // Step 5: Log the outcome to serial so failures are visible without a debugger.
     match &result {
         Ok(tid) => {
             crate::logging::logln(
@@ -273,7 +306,18 @@ pub fn syscall_exec_impl(name_ptr: *const u8) -> SyscallResult<u64> {
         }
     }
 
-    // Step 5: Map ExecError variants to distinct SyscallError codes.
+    // Step 6: On success, record the spawning task as the new task's parent
+    // so `syscall_wait_impl` can later authorize the caller (and only the
+    // caller) to `Wait` on it. Best-effort: if the newly spawned task has
+    // already exited and been reaped by the time this runs (implausible on
+    // a single-CPU cooperative scheduler, but not structurally impossible),
+    // `set_task_parent` simply reports `false` and there is nothing left to
+    // annotate.
+    if let Ok(tid) = result {
+        scheduler::set_task_parent(tid, task_id);
+    }
+
+    // Step 7: Map ExecError variants to distinct SyscallError codes.
     result.map(|tid| tid as u64).map_err(|e| match e {
         ExecError::InvalidName => SyscallError::InvalidArg,
         ExecError::NotFound => SyscallError::InvalidArg,
@@ -289,9 +333,36 @@ pub fn syscall_exec_impl(name_ptr: *const u8) -> SyscallResult<u64> {
 }
 
 /// Implements `Wait(task_id)`: block current task until target task exits.
+///
+/// # Authorization (M10, `docs/CODE_REVIEW_2026-07-26.md`)
+/// Looping `Wait` over a range of task ids lets an unprivileged caller
+/// fingerprint which ids are currently alive (an existence side-channel),
+/// since a live target blocks the caller while an absent one returns
+/// immediately. To close this, a caller without the `privileged` capability
+/// may only `Wait` on a task it actually spawned via `Exec` (tracked by
+/// `TaskEntry::parent`, set in `syscall_exec_impl`); every other target is
+/// rejected with [`SyscallError::PermissionDenied`] *before* the target's
+/// existence is ever checked, so the response does not depend on whether
+/// `task_id` is alive, exited, or was never valid.
+///
+/// A missing caller task context (e.g. this syscall dispatched directly from
+/// kernel/bootstrap/test code rather than through a real ring-3 `int 0x80`)
+/// has no capability to authorize against and is treated as trusted — this
+/// path is unreachable from actual ring-3 callers, since real syscalls are
+/// only ever dispatched while a task is current.
 pub fn syscall_wait_impl(task_id: u64) -> SyscallResult<u64> {
-    // Step 1: Delegate task wait to the scheduler exit queue.
-    scheduler::wait_for_task_exit(task_id as usize);
+    let target = task_id as usize;
+
+    // Step 1: Authorize the caller, if one exists, before touching the
+    // target's liveness state at all.
+    if let Some(caller) = scheduler::current_task_id() {
+        if !scheduler::is_task_privileged(caller) && !scheduler::is_parent_of(caller, target) {
+            return Err(SyscallError::PermissionDenied);
+        }
+    }
+
+    // Step 2: Delegate task wait to the scheduler exit queue.
+    scheduler::wait_for_task_exit(target);
 
     Ok(SYSCALL_OK)
 }

--- a/main64/kernel/tests/process_contract_test.rs
+++ b/main64/kernel/tests/process_contract_test.rs
@@ -646,6 +646,203 @@ fn test_privileged_running_task_passes_shutdown_authorization_check() {
     );
 }
 
+// ── M10: Exec rate limit / Wait scoping authorization (issue #53) ──
+
+/// Contract: a task's `Exec` calls are rejected once it has already spawned
+/// `MAX_CHILD_EXECS` (32) children.
+///
+/// This is the concrete fix for issue #53 (M10 — no per-syscall
+/// authorization for `Exec`): previously any ring-3 task could loop `Exec`
+/// without bound, spawning unprivileged children until scheduler slots or
+/// PMM frames exhausted. `syscall_exec_impl` now increments a per-task
+/// counter *before* touching user memory or the filesystem, so once the cap
+/// is reached every further attempt is denied with
+/// `SYSCALL_ERR_PERMISSION_DENIED` instead of `SYSCALL_ERR_INVALID_ARG` --
+/// this test drives the syscall with a null name pointer (which would
+/// otherwise always fail with `SYSCALL_ERR_INVALID_ARG`) so the distinct
+/// error code observed at the cap boundary can only come from the rate
+/// limiter, not from `read_user_string`.
+#[test_case]
+fn test_exec_denied_after_child_exec_cap_reached() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    // Step 1: Spawn a task and select it as the scheduler's current task, so
+    // `syscall_exec_impl`'s `scheduler::current_task_id()` resolves to it
+    // for every dispatch below.
+    let task_id =
+        process::exec_from_vfs("hello.bin").expect("caller task must spawn for this contract");
+
+    scheduler::start();
+    let mut bootstrap = SavedRegisters::default();
+    let selected = scheduler::on_timer_tick(&mut bootstrap as *mut SavedRegisters);
+    assert_eq!(
+        selected,
+        scheduler::task_frame_ptr(task_id).expect("spawned task must expose a frame pointer"),
+        "first tick must select the freshly spawned task"
+    );
+
+    // Step 2: Exhaust the per-task Exec quota. Every call uses a null name
+    // pointer, so calls that pass the rate-limit check still fail --
+    // deterministically with SYSCALL_ERR_INVALID_ARG -- inside
+    // `read_user_string`, without spawning any further tasks to clean up.
+    for attempt in 0..32 {
+        let ret = syscall::dispatch(SyscallId::Exec as u64, 0, 0, 0, 0);
+        assert_eq!(
+            ret,
+            syscall::SYSCALL_ERR_INVALID_ARG,
+            "attempt {} must still pass the rate limiter and fail on the null pointer",
+            attempt
+        );
+    }
+
+    // Step 3: The next attempt must be denied by the rate limiter itself --
+    // observable because the error code changes from InvalidArg to
+    // PermissionDenied despite passing the exact same (null) arguments.
+    let ret = syscall::dispatch(SyscallId::Exec as u64, 0, 0, 0, 0);
+    assert_eq!(
+        ret,
+        syscall::SYSCALL_ERR_PERMISSION_DENIED,
+        "Exec must be denied once the per-task child cap is reached"
+    );
+
+    assert!(
+        scheduler::terminate_task(task_id),
+        "spawned caller task must be terminatable for test cleanup"
+    );
+}
+
+/// Contract: an unprivileged task may `Wait` on a task it recorded as its own
+/// `Exec`-spawned child.
+///
+/// `syscall_exec_impl` records the caller as `parent` on every successful
+/// spawn; `syscall_wait_impl` must authorize a caller against exactly that
+/// recording. The child is terminated before `Wait` is dispatched so the
+/// call returns immediately via `wait_for_task_exit`'s already-absent fast
+/// path instead of blocking the single-threaded test.
+#[test_case]
+fn test_wait_allowed_for_recorded_parent() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    // Step 1: Spawn and select the parent task as current.
+    let parent_id =
+        process::exec_from_vfs("hello.bin").expect("parent task must spawn for this contract");
+
+    scheduler::start();
+    let mut bootstrap = SavedRegisters::default();
+    let selected = scheduler::on_timer_tick(&mut bootstrap as *mut SavedRegisters);
+    assert_eq!(
+        selected,
+        scheduler::task_frame_ptr(parent_id).expect("spawned task must expose a frame pointer"),
+        "first tick must select the freshly spawned parent task"
+    );
+
+    // Step 2: Spawn a second task and record the parent/child link exactly
+    // as `syscall_exec_impl` would after a successful spawn. Spawning after
+    // the tick above keeps `parent_id` the scheduler's current task.
+    let child_id =
+        process::exec_from_vfs("hello.bin").expect("child task must spawn for this contract");
+    assert!(
+        scheduler::set_task_parent(child_id, parent_id),
+        "parent link must be recorded on a live child slot"
+    );
+    assert!(
+        scheduler::is_parent_of(parent_id, child_id),
+        "precondition: parent link must be observable via is_parent_of"
+    );
+
+    // Step 3: Terminate the child so `Wait` resolves immediately without
+    // blocking this single-threaded test.
+    assert!(
+        scheduler::terminate_task(child_id),
+        "child task must be terminatable ahead of the Wait call"
+    );
+
+    // Step 4: The recorded parent's Wait call must pass authorization and
+    // reach `wait_for_task_exit`, returning success for the now-absent
+    // child.
+    let ret = syscall::dispatch(SyscallId::Wait as u64, child_id as u64, 0, 0, 0);
+    assert_eq!(
+        ret,
+        syscall::SYSCALL_OK,
+        "recorded parent must be authorized to Wait on its own child"
+    );
+
+    assert!(
+        scheduler::terminate_task(parent_id),
+        "parent task must be terminatable for test cleanup"
+    );
+}
+
+/// Contract: `Wait` is denied for an unprivileged task that is not the
+/// recorded parent of the target -- closing the M10 existence side-channel.
+///
+/// Before this fix, any ring-3 task could loop `Wait` over arbitrary task
+/// ids to fingerprint which ids are currently alive (a live target blocks,
+/// an absent one returns immediately). The target here is deliberately left
+/// alive (never terminated) to prove the denial happens purely from the
+/// authorization check, before `wait_for_task_exit` would ever distinguish
+/// "alive" from "absent" -- an unauthorized caller gets the exact same
+/// `SYSCALL_ERR_PERMISSION_DENIED` regardless of the target's true liveness.
+#[test_case]
+fn test_wait_denied_for_non_parent_unprivileged_task() {
+    scheduler::init();
+    scheduler::set_kernel_address_space_cr3(vmm::get_pml4_address());
+
+    // Step 1: Spawn and select the attacker task as current.
+    let attacker_id =
+        process::exec_from_vfs("hello.bin").expect("attacker task must spawn for this contract");
+
+    scheduler::start();
+    let mut bootstrap = SavedRegisters::default();
+    let selected = scheduler::on_timer_tick(&mut bootstrap as *mut SavedRegisters);
+    assert_eq!(
+        selected,
+        scheduler::task_frame_ptr(attacker_id).expect("spawned task must expose a frame pointer"),
+        "first tick must select the freshly spawned attacker task"
+    );
+
+    // Step 2: Spawn an unrelated target task after the tick above, so the
+    // attacker remains the scheduler's current task. No parent link is ever
+    // recorded between the two.
+    let target_id =
+        process::exec_from_vfs("hello.bin").expect("target task must spawn for this contract");
+
+    assert!(
+        !scheduler::is_task_privileged(attacker_id),
+        "precondition: exec-spawned attacker task must be unprivileged"
+    );
+    assert!(
+        !scheduler::is_parent_of(attacker_id, target_id),
+        "precondition: attacker must not be recorded as the target's parent"
+    );
+
+    // Step 3: The unauthorized Wait must be denied without ever consulting
+    // the target's liveness -- the target is still alive at this point.
+    let ret = syscall::dispatch(SyscallId::Wait as u64, target_id as u64, 0, 0, 0);
+    assert_eq!(
+        ret,
+        syscall::SYSCALL_ERR_PERMISSION_DENIED,
+        "non-parent unprivileged task must not be authorized to Wait on an unrelated task id"
+    );
+    assert_eq!(
+        scheduler::task_state(target_id),
+        Some(TaskState::Ready),
+        "a denied Wait call must not alter the target task's lifecycle state"
+    );
+
+    // Cleanup.
+    assert!(
+        scheduler::terminate_task(target_id),
+        "target task must be terminatable for test cleanup"
+    );
+    assert!(
+        scheduler::terminate_task(attacker_id),
+        "attacker task must be terminatable for test cleanup"
+    );
+}
+
 /// Contract: user-program linker scripts place `.text._start` at image base.
 #[test_case]
 fn test_user_program_linker_scripts_prioritize_start_section() {


### PR DESCRIPTION
## Summary

Closes #53.

Fixes the "Exec/Wait/PCI/BIOS enumeration still have no per-syscall authorization" finding (M10, `docs/CODE_REVIEW_2026-07-26.md`), applying the same *stopgap* pattern already used for `Shutdown` (M6) rather than the full capability-gated-driver-syscalls redesign in `docs/drivers.md` (explicitly out of scope).

- **`Exec` (`kernel/src/syscall/dispatch/process.rs`)**: added a per-task `exec_count: u32` field on `TaskEntry` and a new `MAX_CHILD_EXECS = 32` cap. `syscall_exec_impl` calls a new `scheduler::try_increment_exec_count(task_id, MAX_CHILD_EXECS)` *before* touching user memory or the filesystem; once a task hits the cap, every further `Exec` is rejected with `SyscallError::PermissionDenied`. This bounds the DoS scenario from the issue (looping `Exec` to exhaust scheduler slots/PMM frames) without changing behavior for normal shell/script usage.

- **`Wait` (`kernel/src/syscall/dispatch/process.rs`)**: an unprivileged caller may now only `Wait` on a task it actually spawned via `Exec`. `syscall_exec_impl` records the parent/child relationship (via a new `scheduler::set_task_parent`) after every successful spawn; `syscall_wait_impl` checks `scheduler::is_task_privileged(caller) || scheduler::is_parent_of(caller, target)` *before* ever consulting the target's liveness, so an unauthorized caller gets the same `PermissionDenied` regardless of whether the target is alive, exited, or never existed — closing the existence side-channel described in the issue. Parent/child lineage is tracked in a new bounded `SchedulerMetadata::parent_log` ring buffer (capacity 256, FIFO eviction) rather than a field on `TaskEntry`, because `TaskEntry` is wholesale-reset on task reap — a plain field would make a parent lose authorization the moment its own child exits, which is the common case (`Wait` is usually called at-or-after child exit). A caller with no task context (kernel/bootstrap/test-only dispatch, unreachable from real ring-3 syscalls) is treated as trusted, preserving existing test behavior.

- **PCI/BIOS enumeration (`kernel/src/syscall/dispatch/pci.rs`, `bios.rs`)**: deliberately **left ungated**, with the reasoning documented inline on both syscalls. Gating these behind `TaskEntry::privileged` (the mechanism suggested in the issue) would restrict PCI/BIOS-memory-map queries to the boot shell alone, since every `Exec`-spawned task is always unprivileged — but the shipped `TUI.BIN` hardware-inspection screen (`user_programs/tui_app`) is exactly such an unprivileged task and depends on these syscalls to display hardware info. This kernel also has no multi-tenant isolation model between ring-3 tasks that this data would need to be kept secret across. Gating it would regress a shipped feature to mitigate a risk the review itself already downgrades to "information leak, not privilege escalation" — judged not worth it for a stopgap fix.

## Test plan

- Added three tests to `kernel/tests/process_contract_test.rs` mirroring the existing M6 (`Shutdown`) authorization tests:
  - `test_exec_denied_after_child_exec_cap_reached` — drives `Exec` past `MAX_CHILD_EXECS` via `syscall::dispatch`, asserting the error code flips from `SYSCALL_ERR_INVALID_ARG` (null pointer) to `SYSCALL_ERR_PERMISSION_DENIED` once the cap is hit.
  - `test_wait_allowed_for_recorded_parent` — spawns a parent + child, records the link, terminates the child, and asserts the parent's `Wait` succeeds.
  - `test_wait_denied_for_non_parent_unprivileged_task` — spawns an unrelated attacker + target (target left alive), and asserts `Wait` is denied without touching the target's lifecycle state.
- `cargo test` (full suite, 45 test binaries / 455 test cases via QEMU): all pass.
- `cargo clippy -- -D warnings` and `cargo clippy --tests -- -D warnings`: zero warnings.
- `cargo fmt --check`: zero diff.

(Note: `cargo clippy --all-targets` fails on `main` too, pre-existing and unrelated to this change — it tries to build the `#![no_std]` lib/bin unit-test harnesses, which conflict with the crate's custom `no_std` test framework. `--tests` is the correct invocation for the integration test binaries in `kernel/tests/`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)