### PR TITLE
Fix #54: print_captured_target reads capture buffer after releasing logger lock

### DIFF
--- a/main64/kernel/Cargo.toml
+++ b/main64/kernel/Cargo.toml
@@ -123,3 +123,6 @@ name = "test_framework_panic_message_test"
 
 [[test]]
 name = "scroll_dirty_range_test"
+
+[[test]]
+name = "logging_capture_snapshot_test"

--- a/main64/kernel/src/logging.rs
+++ b/main64/kernel/src/logging.rs
@@ -1,6 +1,7 @@
 //! Central kernel logging with optional in-memory capture for console dump.
 
 use crate::sync::spinlock::SpinLock;
+use alloc::vec::Vec;
 use core::fmt::{self, Write as _};
 
 use crate::console::KernelConsole;
@@ -118,29 +119,103 @@ pub fn set_capture_enabled(enabled: bool) {
     });
 }
 
-/// Dump captured logs for one target to the console.
-pub fn print_captured_target(
-    screen: &mut dyn KernelConsole,
-    target: &str,
-    mut highlight: impl FnMut(&str) -> bool,
-) {
-    let (ptr, len, overflow) = with_logger(|state| {
-        (
-            state.capture_buf.as_ptr(),
-            state.capture_len,
-            state.capture_overflow,
-        )
+/// Copies the currently-valid bytes of the capture buffer (plus the overflow
+/// flag) into an owned, heap-allocated buffer while still holding the logger
+/// lock for the copy itself.
+///
+/// This is the fix for issue #54 ("`print_captured_target` reads the capture
+/// buffer after releasing the logger lock"): the previous implementation only
+/// snapshotted a `(ptr, len)` pair under the lock and then read *through*
+/// that raw pointer after the lock was released. `capture_buf` is a
+/// fixed-size array embedded in `LogState` and is never reallocated, so the
+/// pointer itself stayed valid — but nothing prevented another task (woken
+/// via a timer interrupt/preemption, since `capture_target_line` can run
+/// concurrently again the moment the lock is free) from appending to, or
+/// resetting via `set_capture_enabled`, that same live buffer while the slow,
+/// multi-line screen-formatting loop was still reading it. That could garble
+/// or truncate the dump, or make the UTF-8 decode fail outright.
+///
+/// The scratch buffer is allocated *before* the lock is taken, not inside the
+/// locked closure: `heap::malloc`'s success path unconditionally logs an
+/// `"alloc ptr=..."` line through this exact same logger (`with_logger`
+/// again), and `SpinLock` is not reentrant, so allocating while already
+/// holding `LOGGER.inner` would deadlock the CPU spinning against its own
+/// held lock the instant `Vec` needed to grow. Doing the allocation first and
+/// only `copy_from_slice`-ing (no allocation) under the lock keeps the
+/// critical section both allocation-free and cheap — a bounded RAM-to-RAM
+/// copy instead of the comparatively slow act of formatting and writing to
+/// the screen — and guarantees callers read a self-consistent view
+/// regardless of what happens to the live buffer afterward. This mirrors the
+/// pattern already used for issue #16's deferred VRAM flush: snapshot the
+/// cheap state under the lock, then perform the expensive part against the
+/// owned copy, unlocked.
+fn capture_snapshot() -> (Vec<u8>, bool) {
+    // Step 1: Allocate the scratch buffer up front, before touching the
+    // logger lock at all. Sized to the full capture capacity so the copy
+    // below never needs to grow it (no reallocation, hence no further
+    // allocator calls, while the lock from Step 2 is held).
+    let mut scratch: Vec<u8> = alloc::vec![0u8; CAPTURE_BUF_SIZE];
+
+    // Step 2: Copy only the currently-valid bytes under the lock. This is a
+    // plain, allocation-free `copy_from_slice`, so the critical section stays
+    // short and cannot recurse back into `with_logger`.
+    let (len, overflow) = with_logger(|state| {
+        scratch[..state.capture_len].copy_from_slice(&state.capture_buf[..state.capture_len]);
+        (state.capture_len, state.capture_overflow)
     });
 
-    if len == 0 {
-        return;
-    }
+    // Step 3: Trim the scratch buffer down to the bytes that were valid at
+    // snapshot time. `Vec::truncate` only drops the tail elements and updates
+    // the length; for `u8` that is a no-op drop, so this never reallocates
+    // and stays outside the lock.
+    scratch.truncate(len);
 
-    // SAFETY:
-    // - This requires `unsafe` because constructing a slice from a raw pointer requires manually proving pointer validity and bounds.
-    // - `(ptr, len)` originates from `capture_buf` and `capture_len` snapshot.
-    // - Buffer outlives this function and `len` is bounded by capture capacity.
-    let bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
+    (scratch, overflow)
+}
+
+/// Test-only accessor for [`capture_snapshot`].
+///
+/// Exposed so integration tests can verify that formatting reads this owned
+/// snapshot rather than the live capture buffer: a test can take a snapshot,
+/// then mutate the live buffer (simulating a preempting task appending to it
+/// or resetting it via `set_capture_enabled`), and confirm the
+/// already-taken snapshot's contents remain unaffected (issue #54).
+#[doc(hidden)]
+pub fn capture_snapshot_for_test() -> (Vec<u8>, bool) {
+    capture_snapshot()
+}
+
+/// Test-only accessor for [`format_captured_lines`].
+///
+/// Lets integration tests format a previously-taken snapshot (see
+/// [`capture_snapshot_for_test`]) directly, so they can prove formatting
+/// operates purely on that owned copy and is unaffected by later mutations
+/// of the live capture buffer (issue #54).
+#[doc(hidden)]
+pub fn format_captured_for_test(
+    bytes: &[u8],
+    target: &str,
+    overflow: bool,
+    screen: &mut dyn KernelConsole,
+    highlight: impl FnMut(&str) -> bool,
+) {
+    format_captured_lines(bytes, target, overflow, screen, highlight);
+}
+
+/// Formats previously-captured log lines for one `target` to `screen`,
+/// highlighting lines for which `highlight` returns `true`.
+///
+/// Operates purely on the already-copied `bytes`/`overflow` snapshot and does
+/// not touch `LOGGER` at all, so it is safe to call without holding the
+/// logger lock (see `print_captured_target`, which takes the snapshot and
+/// then calls this).
+fn format_captured_lines(
+    bytes: &[u8],
+    target: &str,
+    overflow: bool,
+    screen: &mut dyn KernelConsole,
+    mut highlight: impl FnMut(&str) -> bool,
+) {
     let Ok(text) = core::str::from_utf8(bytes) else {
         return;
     };
@@ -170,4 +245,27 @@ pub fn print_captured_target(
         let _ = writeln!(screen, "[... log output truncated ...]");
     }
     let _ = writeln!(screen, "--- end {} debug ---", target);
+}
+
+/// Dump captured logs for one target to the console.
+pub fn print_captured_target(
+    screen: &mut dyn KernelConsole,
+    target: &str,
+    highlight: impl FnMut(&str) -> bool,
+) {
+    // Step 1: Copy the buffer contents out from under the logger lock (see
+    // `capture_snapshot` for why). This keeps the interrupt-disabling
+    // critical section short and guarantees the formatting pass below reads
+    // a self-consistent view even if capture stays enabled and another task
+    // mutates the live buffer immediately afterward.
+    let (bytes, overflow) = capture_snapshot();
+
+    if bytes.is_empty() {
+        return;
+    }
+
+    // Step 2: Format the owned snapshot. No lock is held here, so the
+    // (comparatively slow) per-line screen writes below no longer keep
+    // interrupts disabled for their entire duration.
+    format_captured_lines(&bytes, target, overflow, screen, highlight);
 }

--- a/main64/kernel/tests/logging_capture_snapshot_test.rs
+++ b/main64/kernel/tests/logging_capture_snapshot_test.rs
@@ -1,0 +1,191 @@
+//! Regression tests for issue #54: `print_captured_target` reads the capture
+//! buffer after releasing the logger lock.
+//!
+//! Before the fix, `logging::print_captured_target` snapshotted only a
+//! `(ptr, len)` pair under `LOGGER`'s lock, then read *through* that raw
+//! pointer after releasing it. `capture_buf` is a fixed-size array embedded
+//! in `LogState` and is never reallocated, so the pointer itself stayed
+//! valid — but nothing stopped another task (woken via a timer interrupt,
+//! since `capture_target_line` can run again the moment the lock is free)
+//! from appending to, or resetting via `set_capture_enabled`, that same live
+//! buffer while the comparatively slow, multi-line screen-formatting loop
+//! was still reading through it. That could garble/truncate the dump, or
+//! make the UTF-8 decode fail and silently return nothing.
+//!
+//! The fix copies the buffer's valid bytes into an owned `Vec<u8>` while
+//! still holding the lock (`logging::capture_snapshot`, exposed here for
+//! testing as `capture_snapshot_for_test`), then formats that owned copy
+//! unlocked (`format_captured_lines`, exposed here as
+//! `format_captured_for_test`). These tests exercise exactly the race
+//! described above: take a snapshot of known content, mutate the *live*
+//! buffer the way a preempting task would, and confirm the already-taken
+//! snapshot's rendered output still reflects the original content only.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(kaos_kernel::testing::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+extern crate alloc;
+
+use alloc::string::String;
+use core::panic::PanicInfo;
+
+use kaos_kernel::arch::interrupts;
+use kaos_kernel::boot_info::VideoModeType;
+use kaos_kernel::console;
+use kaos_kernel::logging;
+use kaos_kernel::memory::{heap, pmm, vmm};
+
+#[no_mangle]
+#[link_section = ".text.boot"]
+pub extern "C" fn KernelMain(_kernel_size: u64) -> ! {
+    kaos_kernel::drivers::serial::init();
+
+    pmm::init(false);
+    interrupts::init();
+    vmm::init(false);
+    heap::init(false);
+
+    test_main();
+
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    kaos_kernel::testing::test_panic_handler(info)
+}
+
+/// VGA text-mode geometry, matching `screen_test.rs`.
+const VGA_BUFFER: usize = 0xFFFF8000000B8000;
+const VGA_COLS: usize = 80;
+const VGA_ROWS: usize = 25;
+
+/// Reads back the entire VGA text-mode buffer's character bytes (skipping
+/// the interleaved color-attribute bytes) into a single `String`, so tests
+/// can assert on rendered content with a plain `contains` check instead of
+/// tracking exact cursor/row/column positions.
+fn vga_text_snapshot() -> String {
+    let mut out = String::with_capacity(VGA_ROWS * VGA_COLS);
+    for row in 0..VGA_ROWS {
+        for col in 0..VGA_COLS {
+            let cell = VGA_BUFFER + ((row * VGA_COLS + col) * 2);
+            // SAFETY:
+            // - This requires `unsafe` because raw pointer memory access is performed directly and Rust cannot verify pointer validity.
+            // - `cell` points to VGA text MMIO for an in-bounds (row, col) cell.
+            // - Volatile read is required for MMIO.
+            let ch = unsafe { core::ptr::read_volatile(cell as *const u8) };
+            out.push(ch as char);
+        }
+    }
+    out
+}
+
+/// Resets the VGA console and the logger's capture buffer to a known,
+/// isolated starting state before each test below runs.
+fn reset_console_and_capture() {
+    console::init(VideoModeType::VgaText);
+    console::with_console(|c| c.clear());
+    logging::set_capture_enabled(true);
+}
+
+/// Contract: formatting an already-taken capture snapshot must render only
+/// the content that was present at snapshot time, even if the live capture
+/// buffer is subsequently appended to and reset (as a preempting task could
+/// do between the lock-protected snapshot and the unlocked formatting pass).
+/// Given: The capture buffer holds one known line for target `csnap54a`.
+/// When: A snapshot is taken (`capture_snapshot_for_test`), the live buffer
+///   is then mutated with different content for the same target, and the
+///   *original* snapshot is formatted (`format_captured_for_test`).
+/// Then: The rendered output must contain the original line and must not
+///   contain the content written after the snapshot was taken.
+/// Failure Impact: A regression here reintroduces issue #54 — the dump could
+///   read torn or entirely different data than what was captured, because
+///   formatting would once again be reading the mutable live buffer instead
+///   of an owned copy.
+#[test_case]
+fn test_formatting_a_snapshot_ignores_later_mutations_of_the_live_buffer() {
+    reset_console_and_capture();
+
+    // Step 1: Capture one known line, then take an owned snapshot of it
+    // while still (implicitly) holding the logger lock, exactly as
+    // `print_captured_target` does internally.
+    logging::logln_with_options("csnap54a", format_args!("line-one-original"), false, true);
+    let (snapshot_bytes, snapshot_overflow) = logging::capture_snapshot_for_test();
+    assert!(
+        core::str::from_utf8(&snapshot_bytes)
+            .unwrap()
+            .contains("csnap54a|line-one-original\n"),
+        "sanity: snapshot must contain the line captured before it was taken"
+    );
+
+    // Step 2: Simulate a task preempting the (real) dump between the
+    // snapshot and the formatting pass: reset capture and log different
+    // content under the same target.
+    logging::set_capture_enabled(true);
+    logging::logln_with_options("csnap54a", format_args!("line-two-MUTATED"), false, true);
+
+    // Sanity check: confirm the live buffer really did change, so the
+    // assertion below is actually exercising snapshot isolation and not
+    // trivially passing because nothing changed.
+    let (live_bytes, _) = logging::capture_snapshot_for_test();
+    assert!(
+        core::str::from_utf8(&live_bytes)
+            .unwrap()
+            .contains("line-two-MUTATED"),
+        "sanity: the live capture buffer must reflect the post-snapshot mutation"
+    );
+
+    // Step 3: Format the *original* snapshot (taken before the mutation).
+    // Its rendered output must be unaffected by the later mutation.
+    console::with_console(|screen| {
+        logging::format_captured_for_test(
+            &snapshot_bytes,
+            "csnap54a",
+            snapshot_overflow,
+            screen,
+            |_| false,
+        );
+    });
+
+    let rendered = vga_text_snapshot();
+    assert!(
+        rendered.contains("line-one-original"),
+        "formatting a snapshot must render the content captured at snapshot time"
+    );
+    assert!(
+        !rendered.contains("line-two-MUTATED"),
+        "formatting a snapshot must not be affected by mutations made to the \
+         live capture buffer after the snapshot was taken"
+    );
+}
+
+/// Contract: `print_captured_target` (the public entry point) still dumps
+/// whatever is currently captured for a target under normal, non-racing
+/// use — i.e. the snapshot-based fix does not change ordinary behavior.
+/// Given: A known line is captured for a distinct target.
+/// When: `print_captured_target` is called for that target.
+/// Then: The rendered output contains the captured message.
+/// Failure Impact: A regression here would mean the fix broke the ordinary
+/// (non-racing) capture-and-dump path relied upon by callers such as
+/// `memory::vmm`'s console debug dump.
+#[test_case]
+fn test_print_captured_target_renders_captured_content() {
+    reset_console_and_capture();
+
+    logging::logln_with_options("csnap54b", format_args!("hello-from-capture"), false, true);
+
+    console::with_console(|screen| {
+        logging::print_captured_target(screen, "csnap54b", |_| false);
+    });
+
+    let rendered = vga_text_snapshot();
+    assert!(
+        rendered.contains("hello-from-capture"),
+        "print_captured_target must render previously captured content for its target"
+    );
+}


### PR DESCRIPTION
## Summary

`logging::print_captured_target` (kernel/src/logging.rs) snapshotted only a `(ptr, len)` pair under `LOGGER`'s lock and then read *through* that raw pointer after releasing the lock. Since `capture_buf` is a fixed-size array embedded in `LogState` that is never reallocated, the pointer itself stayed valid — but nothing prevented another task (woken via a timer interrupt/preemption, since `capture_target_line` can run again the moment the lock is free) from appending to, or resetting via `set_capture_enabled`, the same live buffer while the slow, multi-line screen-formatting loop was still reading it. This could garble/truncate the dump, or make the UTF-8 decode fail and silently return nothing.

There's a real caller of this pattern: `memory::vmm::print_console_debug_output` enables capture, lets ordinary logging append to the buffer, then dumps it later without disabling capture first.

## Fix chosen

Option (b) from the issue: copy the captured bytes into an owned `Vec<u8>` while holding the lock, then format that owned copy after releasing it. I picked this over "hold the lock across the whole format+screen-write loop" because `SpinLock` in this codebase disables interrupts for its entire held duration — keeping interrupts disabled for a slow, multi-line screen dump would be worse than the original bug.

- `capture_snapshot()` copies `capture_buf[..capture_len]` and `capture_overflow` into an owned `Vec<u8>` under the lock.
- `format_captured_lines()` (the former back half of `print_captured_target`) now operates purely on that owned copy, with no lock held.
- `print_captured_target` is unchanged from the caller's perspective (same signature/behavior), just recomposed from these two pieces.

### A second, related bug this surfaced

While building the regression test I hit a real deadlock: the scratch buffer must be allocated **before** taking the lock, not inside the locked closure. `heap::malloc`'s success path unconditionally logs an `"alloc ptr=..."` line through this exact same logger (`with_logger` → `LOGGER.inner.lock()`), and `SpinLock` is not reentrant — so allocating (e.g. via `Vec::to_vec()`) while `LOGGER.inner` was already held caused the CPU to spin against its own held lock the instant the allocator ran. I caught this because the new integration test hung QEMU at 100% CPU; the final fix allocates the scratch buffer up front (sized to the full capture capacity) and only does an allocation-free `copy_from_slice` inside the lock.

## Testing

- Added `kernel/tests/logging_capture_snapshot_test.rs` (registered in `kernel/Cargo.toml`), which:
  - Takes a snapshot of known captured content, then mutates the *live* capture buffer (reset + re-log different content) to simulate a preempting task, and verifies the already-taken snapshot's formatted output still reflects only the original content (not the later mutation).
  - Verifies `print_captured_target`'s ordinary (non-racing) behavior is unchanged.
- `cargo test -p kaos_kernel` (via `cargo test --test logging_capture_snapshot_test`, and spot-checked `vmm_test` [42/42], `heap_test` [27/27], `direct_map_debug_output_test` [1/1] for regressions): all pass.
- `cargo clippy --tests -- -D warnings`: clean, zero warnings.
- `cargo fmt --check`: clean, zero diffs.

Closes #54