### PR TITLE
docs(#49): SAFETY comments for AHCI's DMA/FIS/PRDT unsafe blocks

### DIFF
--- a/main64/kernel/src/drivers/ahci.rs
+++ b/main64/kernel/src/drivers/ahci.rs
@@ -842,6 +842,12 @@ fn do_transfer(
     // - `ACTIVE_PORT` is written exactly once, in `init_ports`, before the
     //   scheduler (and therefore any other caller of `do_transfer`) can run;
     //   after boot it is read-only, so reading it here cannot race a writer.
+    // - When `Some`, the pointer is `&mut (*hba).ports[i]` taken from the
+    //   live `HbaMem` that `try_init_controller` identity-mapped
+    //   uncacheable (`vmm::map_virtual_to_physical_uc`/`configure_uc_mapping`)
+    //   over the ABAR MMIO region reported by BAR5, so it is always non-null
+    //   and points at a live, UC-mapped `HbaPort` register block for as long
+    //   as the kernel runs (this driver never unmaps or reuses that region).
     // - The `is` clear below only clears status bits and does not touch any
     //   state `_request` above doesn't already serialize against other
     //   in-flight transfers.


### PR DESCRIPTION
## Stacked on #79 (issue #48)

This branch is stacked on `fix/issue-48` (issue #48's AHCI lock-scope fix)
and targets that branch as its base, not `main`. Please merge #79 first;
this PR's diff is intentionally just the additional documentation on top
of it.

## Summary

Issue #49 flagged `do_transfer`'s `ACTIVE_PORT` access and the large
command-header/table/FIS/PRDT unsafe block as the highest-risk unsafe code
in the crate with no `SAFETY:` justification at all.

Most of the needed `SAFETY:` comments were already added while restructuring
`do_transfer`'s locking in #48 (that fix and this issue touch the exact same
function, and #49 has to describe the locking as it exists *after* #48, not
before) — see #79's diff for those. This PR:

- Reviewed all four `unsafe` blocks in the now-restructured `do_transfer`
  for accuracy against the post-#48 locking scope specifically:
  - The free-slot-wait and completion-wait busy-poll loops' `SAFETY:`
    comments correctly state that `AHCI_LOCK` is **not** held across
    iterations (only the brief register snapshot is) — i.e. they don't
    blindly repeat the original issue's "AHCI_LOCK serializes all
    command-slot 0 access" framing where that's no longer literally true.
  - The command-programming block's `SAFETY:` comment correctly states
    that this section *is* still one continuous `AHCI_LOCK` hold (it was
    not split further), so the original claim is accurate exactly there.
- Added the one piece of detail from the issue's suggested text that
  wasn't yet spelled out: `ACTIVE_PORT`, when `Some`, is always a
  non-null pointer into a live, UC-mapped `HbaPort` inside the ABAR MMIO
  region that `try_init_controller`/`init_ports` identity-mapped at boot,
  valid for the life of the kernel.
- No correctness gap was found during this review — this is a
  pure-documentation change with no behavior change, so per AGENTS.md's
  testing policy (which requires tests for *functional* changes) no new
  test was added; #79 already added regression tests for the locking
  change itself.

## Test plan

- [x] `cargo test` (all 47 QEMU integration test binaries / 465 test cases,
      including #79's new AHCI tests) passes unchanged.
- [x] `cargo clippy` — zero warnings/errors.
- [x] `cargo fmt --check` — clean.

Fixes #49